### PR TITLE
Use the provided included elements to render nodes

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -301,13 +301,15 @@ class Poi < ActiveRecord::Base
   end
 
   def sponsored?
-    !sponsor.blank? && provided_pois.count > 0
+    !sponsor.blank? && provided_pois.any?
   end
 
   def sponsor
-    providers.each do |p|
-      logo = image_path(p.logo.try(:url, 'iphone'))
-      return logo unless logo.nil?
+    provided_pois.each do |provided_poi|
+      provided_poi.providers.each do |p|
+        logo = image_path(p.logo.try(:url, 'iphone'))
+        return logo unless logo.nil?
+      end
     end
   end
 


### PR DESCRIPTION
This will remove the loading of `providers` for each Node if rendered in `NodesController#index` and therefor speed up loading time of Nodes from more than 450ms to under 150ms on my development machine.

Since there are no tests for this method included, would be great to know if this works as expected.