### PR TITLE
Javascript dependency management via npm and browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ public/system/sitemap*
 public/system/uploads*
 vendor/bundle
 vendor/cache
+node_modules
 .sass-cache
 wheelmap.esproj/Project.espressostorage
 *.espressostorage

--- a/Capfile
+++ b/Capfile
@@ -16,6 +16,7 @@ require 'capistrano/deploy'
 #
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
+require 'capistrano/npm'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/deploytags'

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :assets do
   gem 'compass-colors'
   gem 'compass-rails'
   gem 'bootstrap-sass'
+  gem 'browserify-rails'
 end
 
 group :test, :development do
@@ -120,4 +121,5 @@ group :development do
   gem 'capistrano-rbenv',                   require: false
   gem 'capistrano-bundler',                 require: false
   gem 'capistrano-deploytags', '~> 1.0.0',  require: false
+  gem 'capistrano-npm',                     require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     bourbon (3.2.4)
       sass (~> 3.2)
       thor
+    browserify-rails (0.9.3)
+      sprockets (~> 2.2)
     builder (3.0.4)
     cacheable_flash (0.3.2)
       json
@@ -99,6 +101,8 @@ GEM
       sshkit (~> 1.2)
     capistrano-deploytags (1.0.2)
       capistrano (>= 3.2.0)
+    capistrano-npm (1.0.1)
+      capistrano (>= 3.0.0)
     capistrano-rails (1.1.2)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -483,10 +487,12 @@ DEPENDENCIES
   backup
   big_sitemap
   bootstrap-sass
+  browserify-rails
   cacheable_flash
   capistrano (>= 3.1.0)
   capistrano-bundler
   capistrano-deploytags (~> 1.0.0)
+  capistrano-npm
   capistrano-rails
   capistrano-rbenv
   capybara (= 1.1.1)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ And get some POI data into the database:
     wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.bz2
     bzcat berlin-latest.osm.bz2 | bundle exec rake osm:import
 
+Install all node javascript dependencies:
+
+    npm install
+
 Finally startup a local rails server
 
     bundle exec rails server

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,11 @@ module Wheelmap
       Devise::SessionsController.layout "relaunch"
     end
 
+    # Environments, in which to generate source maps
+    config.browserify_rails.source_map_environments << "development"
+
+    # Should the node_modules directory be evaluated for changes on page load
+    config.browserify_rails.evaluate_node_modules = true
+
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,9 @@ module Wheelmap
       Devise::SessionsController.layout "relaunch"
     end
 
+    # Command line options used when running browserify
+    config.browserify_rails.commandline_options = "-t babelify"
+
     # Environments, in which to generate source maps
     config.browserify_rails.source_map_environments << "development"
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wheelmap",
+  "dependencies" : {
+    "browserify": "~> 10.2.4",
+    "browserify-incremental": "^3.0.1"
+  },
+  "license": "AGPL-3.0",
+  "engines": {
+    "node": ">= 4.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "wheelmap",
-  "dependencies" : {
+  "dependencies": {
+    "babelify": "^6.3.0",
     "browserify": "~> 10.2.4",
     "browserify-incremental": "^3.0.1"
   },
   "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sozialhelden/wheelmap.git"
+  },
   "engines": {
     "node": ">= 4.1"
   }


### PR DESCRIPTION
This PR improves our dependency management of javascript assets.

I still have issues when precompining the assets on deploying:

````
DEBUG [18f32fe4] 	NoMethodError: undefined method `browserify_rails' for #<Rails::Application::Configuration:0x007faff3811118>
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/shared/bundle/ruby/2.2.0/gems/railties-3.2.22/lib/rails/railtie/configuration.rb:85:in `method_missing'
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/releases/20151005211835/config/application.rb:82:in `<class:Application>'
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/releases/20151005211835/config/application.rb:13:in `<module:Wheelmap>'
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/releases/20151005211835/config/application.rb:12:in `<top (required)>'
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/releases/20151005211835/Rakefile:4:in `require'
DEBUG [18f32fe4] 	/var/apps/wheelmap/staging/releases/20151005211835/Rakefile:4:in `<top (required)>'
````

Any ideas?