### PR TITLE
Updates libv8 to make it work with OS X 10.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
       activesupport (>= 3.0)
       librato-rack (~> 0.4.2)
       railties (>= 3.0)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.13)
     libxml-ruby (2.8.0)
     listen (0.7.1)
     lumberjack (1.0.2)


### PR DESCRIPTION
Updates from version 3.16.14.7 to 3.16.14.13.