### PR TITLE
Fix errors on initial db migrations

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,13 @@ Wheelmap::Application.routes.draw do
 
   match '/ping' => 'ping#index'
 
-  ActiveAdmin.routes(self)
+  #
+  # The if statement here is workaround to ensure that users are able to do an initial migration
+  # without problems.
+  # Without this if statement ActiveAdmin complains about missing tables and let the migration fail.
+  # For more details, see https://github.com/activeadmin/activeadmin/issues/783
+  #
+  ActiveAdmin.routes(self) if !$ARGV.nil? && $ARGV.none? { |x| x =~ /migrate|rollback/i}
 
   namespace :admin do
     resources :pois do


### PR DESCRIPTION
PR for #71 

This is a workaround to ensure that users are able to run an initial migration on their database.
Before they failed because ActiveAdmin complained about missing tables which would have been created during migration.