### PR TITLE
Log more information about the current job

### DIFF
--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -20,8 +20,10 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
   def perform
     raise ArgumentError.new("Client cannot be nil") if client.nil?
 
-      logger.info "UpdateTagsJob -------------------------->"
-      logger.info "User: #{user.try(:id)}"
+    logger.info "UpdateTagsJob -------------------------->"
+    logger.info "User: #{user.try(:id)}"
+    logger.info "Element: #{element_id}"
+    logger.info "Tags: #{tags}"
 
     begin
       element_to_compare = api.find_element(type, element_id)

--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -21,9 +21,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
     raise ArgumentError.new("Client cannot be nil") if client.nil?
 
     logger.info "UpdateTagsJob -------------------------->"
-    logger.info "User: #{user.try(:id)}"
-    logger.info "Element: #{element_id}"
-    logger.info "Tags: #{tags}"
+    logger.info "User DB ID: #{user.try(:id)} - User OSM ID: #{user.try(:osm_id)} - Element: #{element_id} - Tags: #{tags}"
 
     begin
       element_to_compare = api.find_element(type, element_id)


### PR DESCRIPTION
PR for #80 
This improves the output for the `UpdateTagsJob`. Additionally to the user id now also the element id and tags are logged.