### PR TITLE
Update Devise to 2.2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install --no-spin
 script:
-  - rake
+  - bundle exec rake
   - npm test
 notifications:
   email:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,9 @@ GEM
       ember-source
       execjs
       handlebars-source
-    bcrypt-ruby (3.1.1)
+    bcrypt (3.1.10)
+    bcrypt-ruby (3.1.5)
+      bcrypt (>= 3.1.3)
     big_sitemap (1.1.0)
     bootstrap-sass (2.3.2.1)
       sass (~> 3.2)
@@ -181,7 +183,7 @@ GEM
     delayed_job_active_record (0.4.4)
       activerecord (>= 2.1.0, < 4)
       delayed_job (~> 3.0)
-    devise (2.2.4)
+    devise (2.2.8)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
       railties (~> 3.1)
@@ -326,7 +328,7 @@ GEM
     omniauth-osm (0.3.0)
       omniauth-oauth (~> 1.0)
     open4 (1.3.0)
-    orm_adapter (0.4.0)
+    orm_adapter (0.5.0)
     pdf-writer (1.1.8)
       color (>= 1.4.0)
       transaction-simple (~> 1.3)
@@ -364,7 +366,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.13.0)
-    rake (10.4.2)
+    rake (10.5.0)
     rb-fsevent (0.9.3)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -471,7 +473,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    warden (1.2.3)
+    warden (1.2.4)
       rack (>= 1.0)
     webmock (1.11.0)
       addressable (>= 2.2.7)


### PR DESCRIPTION
This PR updated Devise to 2.2.8, the last version from the 2.x branch.