### PR TITLE
Update Rspec to v2.99 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :assets do
 end
 
 group :test, :development do
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 2.99'
   gem 'spork'
   gem 'rb-fsevent'
   # gem 'guard'

--- a/Gemfile
+++ b/Gemfile
@@ -88,10 +88,10 @@ group :test, :development do
   gem 'rspec-rails'
   gem 'spork'
   gem 'rb-fsevent'
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'guard-spork'
-  gem 'guard-cucumber', "1.2.2"
+  # gem 'guard'
+  # gem 'guard-rspec'
+  # gem 'guard-spork'
+  # gem 'guard-cucumber', "1.2.2"
   gem 'pry'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,6 @@ group :test do
   gem "capybara", "1.1.1"  # on mac, you need sudo port install libffi
   gem 'cucumber', :require => false
   gem 'cucumber-rails', :require => false
-  gem 'rspec', "2.12.0"
   gem 'autotest', :require => false
   gem 'nokogiri'
   gem 'pickle', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,17 +379,21 @@ GEM
       oauth (>= 0.4.7)
     routing-filter (0.3.1)
       actionpack
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.1)
-    rspec-rails (2.12.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    rspec-rails (2.99.0)
       actionpack (>= 3.0)
+      activemodel (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
+      rspec-collection_matchers
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
     ruby-progressbar (1.3.2)
     rubyzip (1.1.7)
     ruport (1.6.3)
@@ -549,7 +553,7 @@ DEPENDENCIES
   rmagick
   rosemary
   routing-filter
-  rspec-rails
+  rspec-rails (~> 2.99)
   ruby-progressbar
   ruport
   sass (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,7 +574,6 @@ DEPENDENCIES
   rmagick
   rosemary
   routing-filter
-  rspec (= 2.12.0)
   rspec-rails
   ruby-progressbar
   ruport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,21 +234,6 @@ GEM
       activerecord (>= 3.0, < 4.0)
     geocoder (1.1.8)
     gherkin3 (3.1.2)
-    guard (1.6.1)
-      listen (>= 0.6.0)
-      lumberjack (>= 1.0.2)
-      pry (>= 0.9.10)
-      thor (>= 0.14.6)
-    guard-cucumber (1.2.2)
-      cucumber (>= 1.2.0)
-      guard (>= 1.1.0)
-    guard-rspec (2.3.3)
-      guard (>= 1.1)
-      rspec (~> 2.11)
-    guard-spork (1.4.1)
-      childprocess (>= 0.2.3)
-      guard (>= 1.1)
-      spork (>= 0.8.4)
     haml (4.0.3)
       tilt
     handlebars-source (1.0.12)
@@ -294,8 +279,6 @@ GEM
       railties (>= 3.0)
     libv8 (3.16.14.13)
     libxml-ruby (2.8.0)
-    listen (0.7.1)
-    lumberjack (1.0.2)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -396,10 +379,6 @@ GEM
       oauth (>= 0.4.7)
     routing-filter (0.3.1)
       actionpack
-    rspec (2.12.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
     rspec-core (2.12.2)
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
@@ -535,10 +514,6 @@ DEPENDENCIES
   formtastic-bootstrap
   friendly_id (~> 4.0.0)
   geocoder
-  guard
-  guard-cucumber (= 1.2.2)
-  guard-rspec
-  guard-spork
   haml
   has_scope
   htmlentities


### PR DESCRIPTION
This PR updates RSpec to v2.99 to prepare a further upgrade to RSpec v3.x