### PR TITLE
Use temporary model in migration

### DIFF
--- a/db/migrate/20160112153334_change_community_center_to_community_centre.rb
+++ b/db/migrate/20160112153334_change_community_center_to_community_centre.rb
@@ -1,7 +1,6 @@
 class ChangeCommunityCenterToCommunityCentre < ActiveRecord::Migration
   class LocalNodeType < ActiveRecord::Base
     self.table_name = 'node_types'
-    attr_accessible :identifier, :osm_value
     validates :identifier, :osm_value, :presence => true
   end
   def up

--- a/db/migrate/20160112153334_change_community_center_to_community_centre.rb
+++ b/db/migrate/20160112153334_change_community_center_to_community_centre.rb
@@ -1,6 +1,11 @@
 class ChangeCommunityCenterToCommunityCentre < ActiveRecord::Migration
+  class LocalNodeType < ActiveRecord::Base
+    self.table_name = 'node_types'
+
+    validates :identifier, :osm_value, :presence => true
+  end
   def up
-    node_type = NodeType.find_by_identifier('community_center')
+    node_type = LocalNodeType.find_by_identifier('community_center')
     if node_type.nil?
       return
     else
@@ -11,7 +16,7 @@ class ChangeCommunityCenterToCommunityCentre < ActiveRecord::Migration
   end
 
   def down
-    node_type = NodeType.find_by_identifier('community_centre')
+    node_type = LocalNodeType.find_by_identifier('community_centre')
     if node_type.nil?
       return
     else

--- a/db/migrate/20160112153334_change_community_center_to_community_centre.rb
+++ b/db/migrate/20160112153334_change_community_center_to_community_centre.rb
@@ -1,7 +1,7 @@
 class ChangeCommunityCenterToCommunityCentre < ActiveRecord::Migration
   class LocalNodeType < ActiveRecord::Base
     self.table_name = 'node_types'
-
+    attr_accessible :identifier, :osm_value
     validates :identifier, :osm_value, :presence => true
   end
   def up


### PR DESCRIPTION
This PR changes the last migration to use temporary ActiveRecord models.