### PR TITLE
Guard for rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :test, :development do
   gem 'guard'
   gem 'guard-rspec'
   # gem 'guard-spork'
-  gem 'guard-cucumber', "1.2.2"
+  gem 'guard-cucumber', '~> 1.6'
   gem 'pry'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :test, :development do
   gem 'teaspoon', '1.1.1'
   gem 'teaspoon-jasmine'
   gem 'phantomjs'
-  # gem 'guard'
+  gem 'guard'
   # gem 'guard-rspec'
   # gem 'guard-spork'
   # gem 'guard-cucumber', "1.2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ group :test, :development do
   gem 'teaspoon-jasmine'
   gem 'phantomjs'
   gem 'guard'
-  # gem 'guard-rspec'
+  gem 'guard-rspec'
   # gem 'guard-spork'
   # gem 'guard-cucumber', "1.2.2"
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ group :test, :development do
   gem 'phantomjs'
   gem 'guard'
   gem 'guard-rspec'
-  # gem 'guard-spork'
+  gem 'guard-spork'
   gem 'guard-cucumber', '~> 1.6'
   gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :test, :development do
   gem 'guard'
   gem 'guard-rspec'
   # gem 'guard-spork'
-  # gem 'guard-cucumber', "1.2.2"
+  gem 'guard-cucumber', "1.2.2"
   gem 'pry'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
       lumberjack (>= 1.0.2)
       pry (>= 0.9.10)
       thor (>= 0.14.6)
+    guard-cucumber (1.2.2)
+      cucumber (>= 1.2.0)
+      guard (>= 1.1.0)
     guard-rspec (2.3.3)
       guard (>= 1.1)
       rspec (~> 2.11)
@@ -540,6 +543,7 @@ DEPENDENCIES
   friendly_id (~> 4.0.0)
   geocoder
   guard
+  guard-cucumber (= 1.2.2)
   guard-rspec
   haml
   has_scope

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,9 +239,11 @@ GEM
       lumberjack (>= 1.0.2)
       pry (>= 0.9.10)
       thor (>= 0.14.6)
-    guard-cucumber (1.2.2)
-      cucumber (>= 1.2.0)
-      guard (>= 1.1.0)
+    guard-compat (1.2.1)
+    guard-cucumber (1.6.0)
+      cucumber (~> 2.0)
+      guard-compat (~> 1.0)
+      nenv (~> 0.1)
     guard-rspec (2.3.3)
       guard (>= 1.1)
       rspec (~> 2.11)
@@ -311,6 +313,7 @@ GEM
     multi_xml (0.5.3)
     multipart-post (2.0.0)
     mysql2 (0.3.18)
+    nenv (0.2.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -543,7 +546,7 @@ DEPENDENCIES
   friendly_id (~> 4.0.0)
   geocoder
   guard
-  guard-cucumber (= 1.2.2)
+  guard-cucumber (~> 1.6)
   guard-rspec
   haml
   has_scope

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,11 @@ GEM
       activerecord (>= 3.0, < 4.0)
     geocoder (1.1.8)
     gherkin3 (3.1.2)
+    guard (1.6.1)
+      listen (>= 0.6.0)
+      lumberjack (>= 1.0.2)
+      pry (>= 0.9.10)
+      thor (>= 0.14.6)
     haml (4.0.3)
       tilt
     handlebars-source (1.0.12)
@@ -279,6 +284,10 @@ GEM
       railties (>= 3.0)
     libv8 (3.16.14.13)
     libxml-ruby (2.8.0)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    lumberjack (1.0.10)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -523,6 +532,7 @@ DEPENDENCIES
   formtastic-bootstrap
   friendly_id (~> 4.0.0)
   geocoder
+  guard
   haml
   has_scope
   htmlentities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
       lumberjack (>= 1.0.2)
       pry (>= 0.9.10)
       thor (>= 0.14.6)
+    guard-rspec (2.3.3)
+      guard (>= 1.1)
+      rspec (~> 2.11)
     haml (4.0.3)
       tilt
     handlebars-source (1.0.12)
@@ -389,6 +392,10 @@ GEM
       oauth (>= 0.4.7)
     routing-filter (0.3.1)
       actionpack
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.2)
@@ -533,6 +540,7 @@ DEPENDENCIES
   friendly_id (~> 4.0.0)
   geocoder
   guard
+  guard-rspec
   haml
   has_scope
   htmlentities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,10 @@ GEM
     guard-rspec (2.3.3)
       guard (>= 1.1)
       rspec (~> 2.11)
+    guard-spork (1.5.2)
+      childprocess (>= 0.2.3)
+      guard (~> 1.1)
+      spork (>= 0.8.4)
     haml (4.0.3)
       tilt
     handlebars-source (1.0.12)
@@ -548,6 +552,7 @@ DEPENDENCIES
   guard
   guard-cucumber (~> 1.6)
   guard-rspec
+  guard-spork
   haml
   has_scope
   htmlentities


### PR DESCRIPTION
This is a PR for bringing back all guard gems which we need for rspec-update.