### PR TITLE
fix missing rack-cache version error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,7 +372,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.4.7)
-    rack-cache (1.6.0)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack


### PR DESCRIPTION
rack-cache 1.6.0 has been yanked from rubygems.org. We update to 1.6.1 then.