### PR TITLE
Remove inherited resources from node types controller

### DIFF
--- a/app/controllers/node_types_controller.rb
+++ b/app/controllers/node_types_controller.rb
@@ -1,24 +1,24 @@
 class NodeTypesController < ApplicationController
   def index
     if params[:ids]
-      @node_types ||= NodeType.where(id: params[:ids])
+      node_types ||= NodeType.where(id: params[:ids])
     else
-      @node_types = NodeType.all
+      node_types = NodeType.all
     end
 
     respond_to do |format|
       format.json {
         render json: {
-            node_types: @node_types.as_api_response(:ember)
+            node_types: node_types.as_api_response(:ember)
         }
       }
     end
   end
 
   def show
-    @node_type = NodeType.find(params[:id])
+    node_type = NodeType.find(params[:id])
     respond_to do |format|
-      format.json { render json: { node_type: @node_type.as_api_response(:ember) }.to_json }
+      format.json { render json: { node_type: node_type.as_api_response(:ember) }.to_json }
     end
   end
 

--- a/app/controllers/node_types_controller.rb
+++ b/app/controllers/node_types_controller.rb
@@ -1,6 +1,10 @@
 class NodeTypesController < ApplicationController
   def index
-    @node_types = NodeType.all
+    if params[:ids]
+      @node_types ||= NodeType.where(id: params[:ids])
+    else
+      @node_types = NodeType.all
+    end
 
     respond_to do |format|
       format.json {
@@ -20,11 +24,4 @@ class NodeTypesController < ApplicationController
 
   protected
 
-  def collection
-    if params[:ids]
-      @node_types ||= NodeType.where(id: params[:ids])
-    else
-      super
-    end
-  end
 end

--- a/app/controllers/node_types_controller.rb
+++ b/app/controllers/node_types_controller.rb
@@ -21,7 +21,4 @@ class NodeTypesController < ApplicationController
       format.json { render json: { node_type: node_type.as_api_response(:ember) }.to_json }
     end
   end
-
-  protected
-
 end

--- a/app/controllers/node_types_controller.rb
+++ b/app/controllers/node_types_controller.rb
@@ -1,8 +1,4 @@
 class NodeTypesController < ApplicationController
-  inherit_resources
-
-  actions :show
-
   def index
     @node_types = NodeType.all
 
@@ -16,7 +12,8 @@ class NodeTypesController < ApplicationController
   end
 
   def show
-    show! do |format|
+    @node_type = NodeType.find(params[:id])
+    respond_to do |format|
       format.json { render json: { node_type: @node_type.as_api_response(:ember) }.to_json }
     end
   end

--- a/app/controllers/node_types_controller.rb
+++ b/app/controllers/node_types_controller.rb
@@ -1,10 +1,12 @@
 class NodeTypesController < ApplicationController
   inherit_resources
 
-  actions :index, :show
+  actions :show
 
   def index
-    index! do |format|
+    @node_types = NodeType.all
+
+    respond_to do |format|
       format.json {
         render json: {
             node_types: @node_types.as_api_response(:ember)

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe NodeTypesController do
   let!(:node_types) { FactoryGirl::create_list(:node_type, 5) }
-  describe '#index' do
+  describe 'GET index' do
     context 'without ids' do
       before do
         get :index, format: :json
@@ -38,7 +38,7 @@ describe NodeTypesController do
     end
   end
 
-  describe '#show' do
+  describe 'GET show/:id' do
     before do
       get :show, id: node_types.first.id, format: :json
     end

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe NodeTypesController do
-  let!(:node_types) { FactoryGirl::create_list(:node_type, 5) }
   describe 'GET index' do
     context 'without ids' do
       before do
@@ -13,11 +12,12 @@ describe NodeTypesController do
       end
 
       it 'returns a list of node types' do
-        expect(json_response['node_types'].length).to eq 5
+        expect(json_response['node_types'].length).to be > 1
       end
     end
 
     context 'with ids' do
+      let(:node_types) { FactoryGirl::create_list(:node_type, 5) }
       let(:ids) {
         [
           node_types.first.id,
@@ -39,6 +39,7 @@ describe NodeTypesController do
   end
 
   describe 'GET show/:id' do
+    let(:node_types) { FactoryGirl::create_list(:node_type, 5) }
     before do
       get :show, id: node_types.first.id, format: :json
     end

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -13,13 +13,19 @@ describe NodeTypesController do
       end
 
       it 'returns a list of node types' do
-        expect(json_response.length).to eq 1
+        expect(json_response['node_types'].length).to eq 5
       end
     end
 
     context 'with ids' do
+      let(:ids) {
+        [
+          node_types.first.id,
+          node_types.last.id
+        ]
+      }
       before do
-        get :index, ids: node_types.map(&:id), format: :json
+        get :index, ids: ids, format: :json
       end
 
       it 'returns 200 status code' do
@@ -27,7 +33,7 @@ describe NodeTypesController do
       end
 
       it 'returns a list of node types' do
-        expect(json_response['node_types'].length).to eq 5
+        expect(json_response['node_types'].length).to eq 2
       end
     end
   end

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -1,24 +1,40 @@
 require 'rails_helper'
 
 describe NodeTypesController do
-  let(:node_type) { FactoryGirl::create(:node_type) }
+  let(:node_types) { FactoryGirl::create_list(:node_type, 5) }
   describe '#index' do
-    before do
-      get :index, format: :json
+    context 'without ids' do
+      before do
+        get :index, format: :json
+      end
+
+      it 'returns 200 status code' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns a list of node types' do
+        expect(json_response.length).to eq 1
+      end
     end
 
-    it 'returns 200 status code' do
-      expect(response).to have_http_status(:success)
-    end
+    context 'with ids' do
+      before do
+        get :index, ids: node_types.map(&:id), format: :json
+      end
 
-    it 'returns a list of node types' do
-      expect(json_response.length).to eq 1
+      it 'returns 200 status code' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns a list of node types' do
+        expect(json_response['node_types'].length).to eq 5
+      end
     end
   end
 
   describe '#show' do
     before do
-      get :show, id: node_type.id, format: :json
+      get :show, id: node_types.first.id, format: :json
     end
 
     it 'returns 200 status code' do
@@ -26,7 +42,7 @@ describe NodeTypesController do
     end
 
     it 'returns a specific node type' do
-      expect(json_response['node_type']['identifier']).to eq node_type.identifier
+      expect(json_response['node_type']['identifier']).to eq node_types.first.identifier
     end
   end
 

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe NodeTypesController do
-  let(:node_types) { FactoryGirl::create_list(:node_type, 5) }
+  let!(:node_types) { FactoryGirl::create_list(:node_type, 5) }
   describe '#index' do
     context 'without ids' do
       before do

--- a/spec/controllers/node_types_controller_spec.rb
+++ b/spec/controllers/node_types_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe NodeTypesController do
+  let(:node_type) { FactoryGirl::create(:node_type) }
+  describe '#index' do
+    before do
+      get :index, format: :json
+    end
+
+    it 'returns 200 status code' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a list of node types' do
+      expect(json_response.length).to eq 1
+    end
+  end
+
+  describe '#show' do
+    before do
+      get :show, id: node_type.id, format: :json
+    end
+
+    it 'returns 200 status code' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a specific node type' do
+      expect(json_response['node_type']['identifier']).to eq node_type.identifier
+    end
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
This PR removes `inherited_resources` from the `NodeTypesController`

Related to #128 