### PR TITLE
Remove inherited resources from regions controller

### DIFF
--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -1,4 +1,5 @@
 class RegionsController < ApplicationController
+# inherit_resources
 
   layout 'home'
 
@@ -8,11 +9,11 @@ class RegionsController < ApplicationController
   before_filter :set_default_depth
 
   def index
-    @regions = collection
+    # @regions = collection
   end
 
   def show
-    @region = resource
+    # @region = resource
   end
 
 

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -1,5 +1,4 @@
 class RegionsController < ApplicationController
-# inherit_resources
 
   layout 'home'
 
@@ -9,11 +8,11 @@ class RegionsController < ApplicationController
   before_filter :set_default_depth
 
   def index
-    # @regions = collection
+    @regions = Region.all
   end
 
   def show
-    # @region = resource
+    @region = Region.find(params[:id])
   end
 
 

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -1,6 +1,4 @@
 class RegionsController < ApplicationController
-  # Include Inherited Resources behaviour
-  inherit_resources
 
   layout 'home'
 

--- a/spec/controllers/regions_controller_spec.rb
+++ b/spec/controllers/regions_controller_spec.rb
@@ -12,7 +12,7 @@ describe RegionsController do
       expect(response).to render_template(:index)
     end
 
-    it "returns a 200 (OK) ) http status code" do
+    it "returns a 200 http status code" do
       expect(response).to have_http_status(200)
     end
   end
@@ -28,7 +28,7 @@ describe RegionsController do
       expect(response).to render_template(:show)
     end
 
-    it "returns a 200 (OK) ) http status code" do
+    it "returns a 200 http status code" do
       expect(response).to have_http_status(200)
     end
   end

--- a/spec/controllers/regions_controller_spec.rb
+++ b/spec/controllers/regions_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe RegionsController do
+
+  describe "GET #index" do
+
+    before(:each) do
+      get :index, :format => :kml
+    end
+
+    it "renders the regions index page" do
+      expect(response).to render_template(:index)
+    end
+
+    it "returns a 200 (OK) ) http status code" do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "GET #show" do
+    let(:region) { FactoryGirl::create(:region)}
+
+    before(:each) do
+      get :show, id: region.id, format: :kml
+    end
+
+    it "renders the regions detail page" do
+      expect(response).to render_template(:show)
+    end
+
+    it "returns a 200 (OK) ) http status code" do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@
   require 'carrierwave/test/matchers'
   require 'database_cleaner'
   require 'spec_helper'
+  require 'capybara/rails'
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.


### PR DESCRIPTION
This PR removes `inherited resources` from RegionsController.
Related to #128