### PR TITLE
Updates routes in preparation to upgrade to Rails 4.0

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Wheelmap::Application.routes.draw do
 
   apipie
 
-  match '/ping' => 'ping#index'
+  get '/ping', to: 'ping#index'
 
   #
   # The if statement here is workaround to ensure that users are able to do an initial migration
@@ -28,7 +28,7 @@ Wheelmap::Application.routes.draw do
 
   scope "map" do
     root :to => 'home#index'
-    match '/:region_id/:node_type_id/wheelchair/:wheelchair' => 'landing_pages#index'
+    match '/:region_id/:node_type_id/wheelchair/:wheelchair' => 'landing_pages#index', via: [:get, :post, :put, :delete]
   end
 
   devise_for :users, :skip => [:sessions],
@@ -39,12 +39,11 @@ Wheelmap::Application.routes.draw do
 
   devise_scope :user do
     scope 'users' do
-      match '/auth/failure' => 'omniauth_callbacks#failure'
-      get  'sign_up'  => 'devise/sessions#new',     :as => :new_user_session
+      get  '/auth/failure' => 'omniauth_callbacks#failure'
+      get  'sign_up'  => 'devise/sessions#new'
       get  'sign_in'  => 'devise/sessions#new',     :as => :new_user_session
       post 'sign_in'  => 'devise/sessions#create',  :as => :user_session
       get  'sign_out' => 'devise/sessions#destroy', :as => :destroy_user_session
-
     end
   end
 
@@ -52,7 +51,6 @@ Wheelmap::Application.routes.draw do
   resources :terms, :only => :index
   resources :addresses, :only => :index
 
-  resources :node_types, :only => :index
   resources :search, :only => :index
   resources :feeds, :only => :index
   resources :oauth, :only => [] do
@@ -99,7 +97,8 @@ Wheelmap::Application.routes.draw do
 
   resources :user, :only => :new # Fake route for redirection to OSM register page
 
-  match '/api' => 'api/api#index'
+  # match in Rails 3.2 accepts all HTTP actions, therefore we need to define them explicitly
+  match '/api', to: 'api/api#index', via: [:get, :post, :put, :delete]
 
   namespace :api do
     resources :docs,        :only  => [:index]
@@ -148,17 +147,17 @@ Wheelmap::Application.routes.draw do
       end
     end
 
-    match '/users/authenticate' => 'users#authenticate'
+    match '/users/authenticate' => 'users#authenticate', via: [:post]
 
     #Last route in routes.rb
-    match '*a', :to => 'api#not_found', :format => false
+    match '*a', :to => 'api#not_found', :format => false, via: [:get, :post, :put, :delete]
   end
 
-  match "/dashboard",               :to => redirect("https://metrics.librato.com/share/dashboards/3wf885ot?duration=604800")
-  match "/ziemlich-beste-freunde",  :to => redirect("http://blog.wheelmap.org/zbf")
-  match "/goeslondon",              :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
-  match "/goes-london",             :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
-  match '/',                        :to => redirect("/map"), :as => 'roooot'
+  get "/dashboard",               :to => redirect("https://metrics.librato.com/share/dashboards/3wf885ot?duration=604800")
+  get "/ziemlich-beste-freunde",  :to => redirect("http://blog.wheelmap.org/zbf")
+  get "/goeslondon",              :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
+  get "/goes-london",             :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
+  get '/',                        :to => redirect("/map"), :as => 'roooot'
 
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,11 +153,8 @@ Wheelmap::Application.routes.draw do
     match '*a', :to => 'api#not_found', :format => false, via: [:get, :post, :put, :delete]
   end
 
-  get "/dashboard",               :to => redirect("https://metrics.librato.com/share/dashboards/3wf885ot?duration=604800")
-  get "/ziemlich-beste-freunde",  :to => redirect("http://blog.wheelmap.org/zbf")
-  get "/goeslondon",              :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
-  get "/goes-london",             :to => redirect("http://blog.wheelmap.org/mitmachen/goes-london/")
-  get '/',                        :to => redirect("/map"), :as => 'roooot'
+  get "/dashboard", :to => redirect("https://metrics.librato.com/share/dashboards/3wf885ot?duration=604800")
+  get '/',          :to => redirect("/map"), :as => 'roooot'
 
 
 end


### PR DESCRIPTION
This PR prepares the routes for an upgrade from Rails 3.2 to Rails 4.0.

A few things changed from 3.2 to 4.0. For one, named routes cannot be stated multiple times (see `sign_in` and `sign_up`). This constraint may be relaxed in later version of Rails. The `match` statement in Rails 4.0 requires the `:via` argument and does not match implicitly to all HTTP actions. In Rails 3.2 there is already support for specifying actions, e.g. `via: [:get, :post]`. In Rails 4.0 there is also support to specify `via: :all` that handles all actions. Therefore all `match` statements are adjusted and work in both Rails 3.2 and 4.0 (Further info in [3.7 HTTP verb constraints](http://guides.rubyonrails.org/v3.2/routing.html))

Most of the routes are good candidates to have only support for `:get` with probably the exception of `match '/api' => 'api/api#index'`. It's very unlikely that external applications use something different from `:get`, but to not break something for these apps I chose to specify all HTTP actions.