### PR TITLE
Refines test setup with Capybara, support for JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ group :test, :development do
   gem 'rb-fsevent'
   gem 'teaspoon', '1.1.1'
   gem 'teaspoon-jasmine'
-  gem 'phantomjs'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-cucumber', '~> 1.6'
@@ -102,14 +101,18 @@ group :test do
   gem 'minitest'
   gem 'webmock', :require => nil
   gem 'factory_girl_rails'
+
   gem 'capybara', '~> 2.6', '>= 2.6.2' # on mac, you need sudo port install libffi
+  gem 'poltergeist'
+  gem 'phantomjs', :require => 'phantomjs/poltergeist'
+  gem 'database_cleaner'
+
   gem 'cucumber', :require => false
   gem 'cucumber-rails', :require => false
   gem 'autotest', :require => false
   gem 'nokogiri'
   gem 'pickle', :require => false
   gem 'launchy', :require => false
-  gem 'database_cleaner', :require => false
   gem 'shoulda-matchers'
   gem 'syntax'
   gem 'email_spec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       carrierwave (~> 0.5)
     chronic (0.10.2)
     chunky_png (1.3.5)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
@@ -358,6 +359,11 @@ GEM
     pickle (0.5.1)
       cucumber (>= 0.8)
       rake
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyamorous (0.5.0)
       activerecord (~> 3.0)
     polyglot (0.3.5)
@@ -507,6 +513,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
     will_paginate (3.1.0)
@@ -593,6 +602,7 @@ DEPENDENCIES
   omniauth-osm
   phantomjs
   pickle
+  poltergeist
   pry
   rails (= 3.2.22.1)
   rake (~> 10.4)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,13 +2,12 @@
   ENV["RAILS_ENV"] ||= 'test'
   require File.expand_path("../../config/environment", __FILE__)
   require 'rspec/rails'
+  require 'capybara/rails'
+  require 'capybara/rspec'
   require 'factory_girl'
   require 'webmock/rspec'
   require 'carrierwave/test/matchers'
-  require 'database_cleaner'
-  require 'spec_helper'
   require 'helpers'
-  require 'capybara/rails'
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.
@@ -31,11 +30,8 @@
     # examples within a transaction, remove the following line or assign false
     # instead of true.
     config.use_transactional_fixtures = false
-    config.before(:suite) do
+    config.before do
       WebMock.disable_net_connect!(:allow_localhost => true)
-
-      DatabaseCleaner.strategy = :transaction
-      DatabaseCleaner.clean_with(:truncation)
     end
 
     config.include EmailSpec::Helpers
@@ -47,15 +43,6 @@
 
     config.before(:all) do
       Delayed::Job.delete_all
-    end
-
-    config.before(:each) do
-      DatabaseCleaner.start
-    end
-
-
-    config.after(:each) do
-      DatabaseCleaner.clean
     end
 
     # rspec-rails 3 will no longer automatically infer an example group's spec type

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,22 @@
+require 'capybara/poltergeist'
+require 'phantomjs'
+
+# disable logger
+module NullPoltergeistLogger
+  def self.puts(*)
+  end
+end
+
+# Driver setup to find PhantomJS executable and to not fill output with logging
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(
+    app,
+    phantomjs: Phantomjs.path,
+    phantomjs_logger: NullPoltergeistLogger)
+end
+
+Capybara.configure do |config|
+  config.javascript_driver = :poltergeist
+  config.server_port       = 8881
+  config.default_wait_time = 3   # in seconds
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,26 @@
+require 'database_cleaner'
+
+# for reference, see the following
+# http://devblog.avdi.org/2012/08/31/configuring-database_cleaner-with-rails-rspec-capybara-and-selenium/
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
This PR adjusts the test setup with Capybara for better JavaScript support, e.g. mostly for things related to Ember.js. The current setup uses `Rack::Test` (by default) as its driver, which does not work well with JavaScript. The setup prepares test with pages that make use of JavaScript, for example testing the search input field.

* adds [phantomjs](https://github.com/colszowka/phantomjs-gem), a headless Webkit engine for use with the [poltergeist](https://github.com/teampoltergeist/poltergeist) driver to render HTML pages
* prepares Capybara to use poltergeist driver, links to PhantomJS executable and disables logging to not flood the console with unrelated messages
* moves setup of Capybara and Database cleaner to its own files in the support folder
* adjusts the Database cleaner to work well for specs that have the tag `js: true` set. See the discussion [here](http://devblog.avdi.org/2012/08/31/configuring-database_cleaner-with-rails-rspec-capybara-and-selenium/) for more details
* the setup prepares the cucumber test in `features/search.feature` to get implemented