### PR TITLE
Fixes issue with installing PhantomJS on TravisCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,6 @@ group :test do
 
   gem 'capybara', '~> 2.6', '>= 2.6.2' # on mac, you need sudo port install libffi
   gem 'poltergeist'
-  gem 'phantomjs', :require => 'phantomjs/poltergeist'
   gem 'database_cleaner'
 
   gem 'cucumber', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,6 @@ GEM
     pdf-writer (1.1.8)
       color (>= 1.4.0)
       transaction-simple (~> 1.3)
-    phantomjs (2.1.1.0)
     pickle (0.5.1)
       cucumber (>= 0.8)
       rake
@@ -600,7 +599,6 @@ DEPENDENCIES
   nokogiri
   oauth
   omniauth-osm
-  phantomjs
   pickle
   poltergeist
   pry

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Restart your shell and install bundler:
 
     brew install imagemagick
 
+#### PhantomJS
+
+PhantomJS is a testing framework for headless testing.
+
+To install on OSX
+
+```
+$ brew install phantomjs   # via Homebrew
+# or
+$ port install phantomjs   # via MacPorts
+```
+
+On Ubuntu 12.04, see either [this description](https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to) or run:
+
+```
+$ sudo apt-get install phantomjs
+```
+
+
 ### Clone the app from Github
 
     git clone https://github.com/sozialhelden/wheelmap.git --depth 1

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,4 @@
 require 'capybara/poltergeist'
-require 'phantomjs'
 
 # disable logger
 module NullPoltergeistLogger
@@ -7,11 +6,10 @@ module NullPoltergeistLogger
   end
 end
 
-# Driver setup to find PhantomJS executable and to not fill output with logging
+# Driver setup to not fill output with logging
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(
     app,
-    phantomjs: Phantomjs.path,
     phantomjs_logger: NullPoltergeistLogger)
 end
 


### PR DESCRIPTION
This PR fixes an issue with installing PhantomJS on the Travis CI server.

A few of the recents builds failed due to a problem with the download of PhantomJS when the ruby gem is used. The [phantomjs gem](https://github.com/colszowka/phantomjs-gem) downloads the package from the main host service (bitbucket). Most CI servers have fixed IP addresses and hit download limitations if a lot of builds download the same package from the same location in a short period. This also happens for TravisCI (and other CI services). For more detailed information on this issue see [this discussion](https://github.com/ariya/phantomjs/issues/13953).

TravisCI knows this issue and already has this package pre-installed in their environments (see [documentation](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-PhantomJS)), making this gem as not required, at least on the CI server. My recommendation is to install PhantomJS separately on the local machine (see README) and not via the Gemfile. Using the prepackaged version on TravisCI avoids build problems.

* removes gem
* adds information on how to install PhantomJS on the development machine for testing