### PR TITLE
Remove old legacy ie.js 

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,6 @@
       %meta{:name => 'description', :content => t('header.meta.description')}
       %title=t('header.title')
 
-    = render :partial => 'shared/html5_elements'
-
     = content_for :javascript_constants
 
     = stylesheet_link_tag :screen, :media => 'screen, projection'

--- a/app/views/layouts/home.html.haml
+++ b/app/views/layouts/home.html.haml
@@ -12,8 +12,6 @@
       %meta{:name => 'description', :content => t('header.meta.description')}
       %title=t('header.title')
 
-    = render :partial => 'shared/html5_elements'
-
     = content_for :javascript_constants
 
     = stylesheet_link_tag :screen, :media => 'screen, projection'

--- a/app/views/layouts/legacy.html.haml
+++ b/app/views/layouts/legacy.html.haml
@@ -11,9 +11,6 @@
       %meta{:name => 'description', :content => t('header.meta.description')}
       %title=t('header.title')
 
-
-    = render :partial => 'shared/html5_elements'
-
     = content_for :javascript_constants
 
     = stylesheet_link_tag :node, :media => 'screen, projection'

--- a/app/views/layouts/simple.html.haml
+++ b/app/views/layouts/simple.html.haml
@@ -9,9 +9,6 @@
       %meta{:name => 'description', :content => t('header.meta.description')}
       %title=t('header.title')
 
-
-    = render :partial => 'shared/html5_elements'
-
     = content_for :javascript_constants
 
     = stylesheet_link_tag :node, :media => 'screen, projection'

--- a/app/views/shared/_html5_elements.html.haml
+++ b/app/views/shared/_html5_elements.html.haml
@@ -1,2 +1,0 @@
-/[if IE]
-  = javascript_include_tag :ie, :media => 'screen, projection'

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,7 @@ module Wheelmap
     config.assets.precompile += ['active_admin.css', 'active_admin.js']
 
     config.assets.precompile += %w( relaunch.css relaunch_ie.css screen.css node.css nodes.css search.css react-select.css)
-    config.assets.precompile += %w( relaunch.js ie.js modernizr.js default.js search.js nodes.js ember.js ember-data.js app.js test.js)
+    config.assets.precompile += %w( relaunch.js modernizr.js default.js search.js nodes.js ember.js ember-data.js app.js test.js)
     config.assets.precompile += %w( i18n/*.js react-application.js )
 
     # Version of your assets, change this if you want to expire all your assets


### PR DESCRIPTION
The ie.js file was used to polyfill HTML 5 in IE 8 and older. But according to our analytics the IE 8 usage drops below 0.5 %.

I removed the file when I added the new node layout. This PR fixes old references to the polyfill.