### PR TITLE
Set higher value for key space limit

### DIFF
--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,0 +1,7 @@
+
+# This is a temporary workaround to fix 'RangeError: exceeded available param key
+# space error', pls see https://github.com/rack/rack/issues/318. When upgrading
+# Rails pls consider to check again.
+if Rack::Utils.respond_to?("key_space_limit=")
+  Rack::Utils.key_space_limit = 262144 # 4 times the default size
+end


### PR DESCRIPTION
During the deployment process Capistrano sometimes stops at ` Running /usr/bin/env sudo /etc/init.d/unicorn_production upgrade`. This PR is a fix for the error message: `RangeError: exceeded available parameter key space` . 

For further background infos, pls follow the discussions here:
https://github.com/rack/rack/issues/318

