### PR TITLE
Fix usage of lat lng query parameters in ember app.

### DIFF
--- a/app/assets/javascripts/WidgetBuilder/Form.js
+++ b/app/assets/javascripts/WidgetBuilder/Form.js
@@ -66,7 +66,7 @@ class WidgetBuilderForm extends React.Component {
                 <I18n scope={'users.profile.widget.center'}/>
               </label>
               <span className="form-wrapper">
-                <Photon url={'http://photon.komoot.de/api/'} lang={I18n.locale} limit={10}
+                <Photon url={'//photon.komoot.de/api/'} lang={I18n.locale} limit={10}
                         placeholder={I18n.t('users.profile.widget.empty_center')}
                         searchPromptText={I18n.t('users.profile.widget.empty_center')}
                         onSelectLocation={this.props.changeLocation} />

--- a/app/assets/javascripts/WidgetBuilder/Preview.js
+++ b/app/assets/javascripts/WidgetBuilder/Preview.js
@@ -16,7 +16,7 @@ class WidgetBuilderPreview extends React.Component {
     let widget = this.props.widget,
       prevWidget = prevProps.widget;
 
-    if (widget.src === prevWidget.src && widget.categories !== prevWidget.categories)
+    if (widget.src !== prevWidget.src || widget.categories !== prevWidget.categories)
       this.refs.iframe.contentWindow.location.reload();
   }
 
@@ -29,7 +29,7 @@ class WidgetBuilderPreview extends React.Component {
           <I18n scope="users.profile.widget.legends.preview" />
         </h5>
         <div className="user-widget-preview-area">
-          <iframe className="user-widget-preview-frame" width={width} height={height} src={src} />
+          <iframe className="user-widget-preview-frame" width={width} height={height} src={src} ref="iframe" />
         </div>
       </div>
     );

--- a/app/assets/javascripts/common/helpers/photon.js
+++ b/app/assets/javascripts/common/helpers/photon.js
@@ -1,7 +1,7 @@
 const { fetchJSON } = require('./api');
 const setParams = require('./setParams');
 
-const PHOTON = 'http://photon.komoot.de';
+const PHOTON = '//photon.komoot.de';
 const PHOTON_API = PHOTON + '/api';
 const PHOTON_REVERSE = PHOTON + '/reverse';
 


### PR DESCRIPTION
This should fix not updating Wheelmap widget location inside the widget builder.

It's not the best solution and I found out that the Ember App trys to update the location of the map multiple times. This needs to be urgently refactored. See #23.

Fixes #213.