### PR TITLE
Do not log conflict exception when node hasn't been changed

### DIFF
--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -48,7 +48,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
 
       # Ignore this job, as there are no changes to be saved
       if comparison_value == 0
-        logger.info "IGNORE: #{type}:#{element_id} nothing has changed!"
+        logger.info "IGNORE: #{type}:#{element_id} nothing has changed! (value comparison)"
         return
       end
 
@@ -68,8 +68,9 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
         user.increment!(:edit_counter) if user.terms?
       end
     rescue Rosemary::Conflict => conflict
+      logger.info "IGNORE: #{type}:#{element_id} nothing has changed! (conflict)"
       # These changes have already been made, so dismiss this update!
-      logger.info "IGNORE: #{type}:#{element_id} nothing has changed!"
+      Airbrake.notify(conflict, :component => 'UpdateTagsJob#perform', :parameters => {:user => user.inspect, :element => element.inspect, :client => client})
     end
   end
 

--- a/spec/jobs/update_tags_job_spec.rb
+++ b/spec/jobs/update_tags_job_spec.rb
@@ -84,20 +84,6 @@ describe UpdateTagsJob do
 
   end
 
-  it "does not update tag counter when node did not change" do
-    job = UpdateTagsJob.enqueue(poi.id.abs, poi.osm_type, poi.tags, user, 'update_iphone')
-    unedited_node = Rosemary::Node.new(poi.to_osm_attributes)
-    api = double(:find_or_create_open_changeset => changeset)
-    expect(Rosemary::Api).to receive(:new).and_return(api)
-    expect(api).to receive(:find_element).with('node', node.id.abs).and_return(unedited_node)
-    expect(Counter).not_to receive(:increment)
-    successes, failures = Delayed::Worker.new.work_off
-    expect(successes).to eql 1
-    expect(failures).to eql 0
-
-  end
-
-
   it "updates tag counter" do
     job = UpdateTagsJob.enqueue(poi.id.abs, 'node', { 'wheelchair' => 'no' }, user, 'update_iphone')
     api = double(:find_or_create_open_changeset => changeset)

--- a/spec/jobs/update_tags_job_spec.rb
+++ b/spec/jobs/update_tags_job_spec.rb
@@ -38,7 +38,7 @@ describe UpdateTagsJob do
 
   end
 
-  it "should not update when no changes have been made" do
+  it "should not update the node when nothing has been changed" do
     job = UpdateTagsJob.enqueue(poi.id.abs, poi.osm_type, poi.tags, user, 'update_iphone')
     unedited_node = Rosemary::Node.new(poi.to_osm_attributes)
     api = double(:find_or_create_open_changeset => changeset)
@@ -67,22 +67,6 @@ describe UpdateTagsJob do
     successes, failures = Delayed::Worker.new.work_off
     expect(successes).to eql 1
     expect(failures).to eql 0
-
-  end
-
-  it "should not update the node when nothing has been changed" do
-    job = UpdateTagsJob.enqueue(poi.id.abs, poi.osm_type, poi.tags, user, 'update_iphone')
-
-    unedited_node = Rosemary::Node.new(poi.to_osm_attributes)
-    api = double(:find_or_create_open_changeset => changeset)
-
-    expect(Rosemary::Api).to receive(:new).and_return(api)
-    expect(api).to receive(:find_element).with('node', node.id.abs).and_return(unedited_node)
-    expect(api).not_to receive(:save)
-    successes, failures = Delayed::Worker.new.work_off
-    expect(successes).to eql 1
-    expect(failures).to eql 0
-
 
   end
 


### PR DESCRIPTION
This PR solves issue #184. 