### PR TITLE
Update inherited_resources to 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :default do
   gem "routing-filter"
   gem 'newrelic_rpm'
   gem 'acts_as_api'
-  gem 'inherited_resources', '~> 1.4.0'
+  gem 'inherited_resources', '~> 1.6.0'
   gem 'has_scope'
   gem 'rake', '~> 10.4'
   gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,9 +256,11 @@ GEM
     i18n (0.6.11)
     i18n-js (3.0.0.rc12)
       i18n (~> 0.6, >= 0.6.6)
-    inherited_resources (1.4.1)
+    inherited_resources (1.6.0)
+      actionpack (>= 3.2, < 5)
       has_scope (~> 0.6.0.rc)
-      responders (~> 1.0.0.rc)
+      railties (>= 3.2, < 5)
+      responders
     journey (1.0.4)
     jquery-rails (2.3.0)
       railties (>= 3.0, < 5.0)
@@ -306,7 +308,7 @@ GEM
     mime-types (1.25.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
-    multi_json (1.11.2)
+    multi_json (1.12.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.20)
@@ -384,8 +386,8 @@ GEM
       rails (>= 3.2)
       tilt
     ref (2.0.0)
-    responders (1.0.0)
-      railties (>= 3.2, < 5)
+    responders (1.1.2)
+      railties (>= 3.2, < 4.2)
     rgeo (0.5.2)
     rgeo-activerecord (0.4.6)
       activerecord (>= 3.0.3)
@@ -555,7 +557,7 @@ DEPENDENCIES
   htmlentities
   i18n (< 0.7.0)
   i18n-js (~> 3.0.0.rc9)
-  inherited_resources (~> 1.4.0)
+  inherited_resources (~> 1.6.0)
   jquery-rails (= 2.3.0)
   js-routes
   kaminari (~> 0.14)


### PR DESCRIPTION
In preparation to update `activeadmin`, `inherited_resources` needs to get updated to version 1.6.