### PR TITLE
This removes the search_methods call from the poi model

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -92,9 +92,6 @@ class Poi < ActiveRecord::Base
   scope :within_region, lambda {|region| {:conditions => {:region_id => region.id}}}
   scope :region_id_eq, lambda {|region_id|  where(region_id: Region.find(region_id).self_and_descendants.map(&:id))}
 
-  # TODO Must be checked how to implement search_methods with the ransack gem
-  # search_methods :region_id_eq
-
   scope :within_bbox, lambda {|left, bottom, right, top|{
     :conditions => "MBRContains(GeomFromText('POLYGON(( \
                     #{left} #{bottom}, #{right} #{bottom}, \


### PR DESCRIPTION
Related to #244 and fixes #238 
Right now filtering by region works out of the box with ransack without any additional configuration