### PR TITLE
Fix broken button calls

### DIFF
--- a/app/admin/node_type.rb
+++ b/app/admin/node_type.rb
@@ -41,7 +41,7 @@ ActiveAdmin.register NodeType do
       f.input :alt_osm_value
 
     end
-    f.buttons
+    f.actions
   end
 
 

--- a/app/admin/region.rb
+++ b/app/admin/region.rb
@@ -65,7 +65,7 @@ ActiveAdmin.register Region do
     f.inputs do
       f.input :name
     end
-    f.buttons
+    f.actions
   end
 
 end


### PR DESCRIPTION
PR for #244 
This PR fixes the two broken admin forms `region` and `node_type`. Those contained calls to `buttons` but the `buttons` method has been replaced by `actions`.