### PR TITLE
Fix removed ActiveAdmin methods

### DIFF
--- a/app/admin/address.rb
+++ b/app/admin/address.rb
@@ -26,6 +26,6 @@ ActiveAdmin.register Address do
     end
     column :name
     column :address
-    default_actions
+    actions
   end
 end

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register AdminUser do
     column :current_sign_in_at
     column :last_sign_in_at
     column :sign_in_count
-    default_actions
+    actions
   end
 
   filter :email

--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Category do
     column :id
     column :identifier
     column :name, :sortable => false
-    default_actions
+    actions
   end
 
 

--- a/app/admin/node_type.rb
+++ b/app/admin/node_type.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register NodeType do
     column :osm_value, :sortable => :osm_value  do |node_type|
       link_to node_type.osm_value, "http://wiki.openstreetmap.org/wiki/Tag:#{node_type.osm_key}%3D#{node_type.osm_value}", :target => '_blank'
     end
-    default_actions
+    actions
   end
 
   form do |f|

--- a/app/admin/photos.rb
+++ b/app/admin/photos.rb
@@ -37,7 +37,7 @@ ActiveAdmin.register Photo do
     end
     column :taken_at
     column :created_at
-    default_actions
+    actions
   end
 
   form html: { multipart: true } do |f|
@@ -48,7 +48,7 @@ ActiveAdmin.register Photo do
     f.inputs do
       f.input :image
       f.input :caption
-      f.input :taken_at, as: :datetime
+      f.input :taken_at
     end
     f.actions
   end

--- a/app/admin/poi.rb
+++ b/app/admin/poi.rb
@@ -79,7 +79,7 @@ ActiveAdmin.register Poi do
     column :photos, :sortable => true do |poi|
       link_to "Photos", admin_poi_photos_path(poi) if poi.photos.size > 0
     end
-    default_actions
+    actions
   end
 
   show :title => :headline do |poi|

--- a/app/admin/provided_poi.rb
+++ b/app/admin/provided_poi.rb
@@ -47,7 +47,7 @@ ActiveAdmin.register ProvidedPoi do
    end
    column :provider
    column :url
-   default_actions
+   actions
   end
 
   form do |f|

--- a/app/admin/provider.rb
+++ b/app/admin/provider.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register Provider do
   index do
     column :id
     column :name
-    default_actions
+    actions
   end
 
   form html: { multipart: true } do |f|

--- a/app/admin/region.rb
+++ b/app/admin/region.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Region do
     column :name
     column :depth
     column :parent
-    default_actions
+    actions
   end
 
   show do |r|

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -59,7 +59,7 @@ ActiveAdmin.register User do
     column 'POIs tagged', :tag_counter
     column 'POIs edited', :edit_counter
     column 'POIs created', :create_counter
-    default_actions
+    actions
   end
 
   form do |f|


### PR DESCRIPTION
This PR fixes method calls which failed originally. We already fixed some of these in #259 but some changes got lost during the merge. 
They got lost because we needed to revert a previous PR containing some of these changes and apparently that revert went wrong.