### PR TITLE
Fix RuntimeError for Testing: undefined method `caches_page`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :default do
   gem 'ruport'
 
   gem 'dalli'
+  gem 'actionpack-page_caching', '~> 1.0', '>= 1.0.2'
 
   gem 'big_sitemap'
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
+    actionpack-page_caching (1.0.2)
+      actionpack (>= 4.0.0, < 5)
     active_model_serializers (0.9.4)
       activemodel (>= 3.2)
     activeadmin (1.0.0.pre2)
@@ -516,6 +518,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-page_caching (~> 1.0, >= 1.0.2)
   activeadmin (~> 1.0.0.pre2)
   activerecord-import (< 0.3.0)
   activerecord-mysql2spatial-adapter (~> 0.5.0.nonrelease)


### PR DESCRIPTION
When trying to run the tests, we experienced a runtime error at:
```
/home/vagrant/wheelmap/app/controllers/api/docs/resources_controller.rb:3:in `<class:ResourcesController>': undefined method `caches_page' for Api::Docs::ResourcesController:Class (NoMethodError)
```
We found out that page caching has been removed from Actionpack since Rails 4.0.

This PR fixes this issue and adds the gem 'actionpack-page_caching' separately.