### PR TITLE
Pin Shoulda-Matchers & require it in rails_helper.rb.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :test do
   gem 'nokogiri'
   gem 'pickle', :require => false
   gem 'launchy', :require => false
-  gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
+  gem 'shoulda-matchers', '~> 3.1'
   gem 'syntax'
   gem 'email_spec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :test do
   gem 'nokogiri'
   gem 'pickle', :require => false
   gem 'launchy', :require => false
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', '~> 3.0'
   gem 'syntax'
   gem 'email_spec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :test do
   gem 'nokogiri'
   gem 'pickle', :require => false
   gem 'launchy', :require => false
-  gem 'shoulda-matchers', '~> 3.0'
+  gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
   gem 'syntax'
   gem 'email_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,7 +609,7 @@ DEPENDENCIES
   ruport
   sass (~> 3.3)
   sass-rails
-  shoulda-matchers (~> 3.0)
+  shoulda-matchers (~> 3.1, >= 3.1.1)
   simple_form
   syntax
   test-unit (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,7 +609,7 @@ DEPENDENCIES
   ruport
   sass (~> 3.3)
   sass-rails
-  shoulda-matchers (~> 3.1, >= 3.1.1)
+  shoulda-matchers (~> 3.1)
   simple_form
   syntax
   test-unit (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,7 +609,7 @@ DEPENDENCIES
   ruport
   sass (~> 3.3)
   sass-rails
-  shoulda-matchers
+  shoulda-matchers (~> 3.0)
   simple_form
   syntax
   test-unit (~> 3.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,17 +61,7 @@
 
   Shoulda::Matchers.configure do |config|
     config.integrate do |with|
-      # Choose a test framework:
       with.test_framework :rspec
-      # with.test_framework :minitest
-      # with.test_framework :minitest_4
-      # with.test_framework :test_unit
-
-      # Choose one or more libraries:
-      # with.library :active_record
-      # with.library :active_model
-      # with.library :action_controller
-      # Or, choose the following (which implies all of the above):
       with.library :rails
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@
   require 'factory_girl'
   require 'webmock/rspec'
   require 'carrierwave/test/matchers'
+  require 'shoulda-matchers'
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.
@@ -56,4 +57,21 @@
 
     # replace deprecated ExampleGroup#example
     config.expose_current_running_example_as :example
+  end
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      # Choose a test framework:
+      with.test_framework :rspec
+      # with.test_framework :minitest
+      # with.test_framework :minitest_4
+      # with.test_framework :test_unit
+
+      # Choose one or more libraries:
+      # with.library :active_record
+      # with.library :active_model
+      # with.library :action_controller
+      # Or, choose the following (which implies all of the above):
+      with.library :rails
+    end
   end


### PR DESCRIPTION
This PR fixes #241 warnings in testings (belong_to, have_many, validate_presence_of, validate_uniqueness_of).