### PR TITLE
remove failing photos controller test

### DIFF
--- a/spec/controllers/api/photos_controller_spec.rb
+++ b/spec/controllers/api/photos_controller_spec.rb
@@ -83,11 +83,6 @@ describe Api::PhotosController do
         expect(response.status).to eql 201
       }.to change(Photo, :count).by(1)
     end
-
-    it "is not possible to upload images for a user" do
-      post(:create, :url => api_user_photos_path, :api_key => user.authentication_token, :photo => {:image => fixture_file_upload('/placeholder.jpg')})
-      expect(response.status).to eql 400
-    end
   end
 
   context 'destroy action' do


### PR DESCRIPTION
We remove this test because it tests Ruby on Rails behavior here. The
test starts failing with Rails 4.x where it passed before with Rails
3.2.x. Rails by itself doesn't allow to send a POST request to a route
which accepts GET only.