### PR TITLE
Fix first batch of deprecation warnings

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,10 +43,6 @@ Wheelmap::Application.configure do
 
   config.assets.digest = false
 
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 2.0
-
   config.ember.variant = :development
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,9 +14,6 @@ Wheelmap::Application.configure do
                                                         :urlencode => false
                                                       }
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,6 +18,8 @@ Wheelmap::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.eager_load = false
+
   # Raise exception on mass assignment protection for Active Record models
   config.active_record.mass_assignment_sanitizer = :strict
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,6 +16,8 @@ Wheelmap::Application.configure do
   # Compress JavaScripts and CSS
   config.assets.compress = true
 
+  config.eager_load = true
+
   # @TODO Enable compressors and find alternative for :yui
   # Compress CSS and JS faster in production
   # config.assets.css_compressor = :yui

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -12,6 +12,8 @@ Wheelmap::Application.configure do
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
+  config.eager_load = true
+
   # Compress JavaScripts and CSS
   config.assets.compress = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,9 +14,6 @@ Wheelmap::Application.configure do
   # Raise exception on mass assignment protection for Active Record models
   #config.active_record.mass_assignment_sanitizer = :strict
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,8 @@ Wheelmap::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
+  config.eager_load = false
+
   # Raise exception on mass assignment protection for Active Record models
   #config.active_record.mass_assignment_sanitizer = :strict
 


### PR DESCRIPTION
This PR fixes the first deprecation warnings.

- It removes `config.whiny_nils`
- It removes `config.active_record.auto_explain_threshold_in_seconds`
- It sets `config.eager_load` for all environments
