### PR TITLE
set available locales for staging env as well

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -81,6 +81,7 @@ Wheelmap::Application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
   config.i18n.fallbacks = true
+  config.i18n.available_locales = [:ar, :bg, :da, :de, :el, :en, :es, :fr, :hu, :is, :it, :ja, :ko, :lv, :pl, :pt_BR, :ru, :sk, :sv, :tlh, :tr, :zh_TW]
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify


### PR DESCRIPTION
Before these values were only set for the production environment. 

This fixes the broken `asset:precompile` task which causes deployments on staging to fail.