### PR TITLE
Fix belongs_to deprecated include option in Poi

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -32,7 +32,7 @@ class Poi < ActiveRecord::Base
   WHEELCHAIR_TOILET_VALUES = {:yes => true, :no => false, :unknown => nil}
 
   belongs_to :region, :touch => false
-  belongs_to :node_type, :touch => false, :include => :category
+  belongs_to :node_type, -> { includes(:category) }, touch: false
   has_one :category, :through => :node_type
 
   validate :relevant?


### PR DESCRIPTION
PR for #236 

Fix deprecation warning (`Poi.belongs_to :node_type declaration are deprecated: :include`) in Poi model 