### PR TITLE
Change installation infos for phantomjs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ port install phantomjs   # via MacPorts
 On Ubuntu 12.04, run:
 
 ```
-$ sudo npm install -g phantomjs
+$ sudo npm install -g phantomjs-prebuilt
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ $ brew install phantomjs   # via Homebrew
 $ port install phantomjs   # via MacPorts
 ```
 
-On Ubuntu 12.04, see either [this description](https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to) or run:
+On Ubuntu 12.04, run:
 
 ```
-$ sudo apt-get install phantomjs lbwebp2 libicu48 libjpeg8 libfontconfig
+$ sudo npm install -g phantomjs
 ```
 
 


### PR DESCRIPTION
The previous installation infos for phantomjs on Ubuntu 12.04 are now failing in the tests in the virtual machine when we do a fresh vagrant start up.

**Errors:**
`E: Unable to locate package lbwebp2`
`[WARNING] phantomjs: cannot connect to X server`

This PR changes the installation instructions from ubuntu packages to npm global install and removes the text part & link where it doesn't make sense anymore.
