### PR TITLE
Add Berlin Code of Conduct (EN) to project & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ And visit the website in your browser: `http://0.0.0.0:3000`
 
 Please also check our [WIKI](https://github.com/sozialhelden/wheelmap/wiki), if you need more informations to specific topics and can't find them here, e.g. how to generate a sprite or how to test our app.
 
+## Code of Conduct
+
+We refer to the [Berlin Code of Conduct](http://berlincodeofconduct.org/) and friendly ask all contributors and people involved to comply with it. 
+
 ## License
 
 The Wheelmap Software is released under the [GNU Affero General Public License v3.0](/LICENSE).

--- a/codeofconduct_en.md
+++ b/codeofconduct_en.md
@@ -1,0 +1,1 @@
+Not Found

--- a/codeofconduct_en.md
+++ b/codeofconduct_en.md
@@ -1,1 +1,73 @@
-Not Found
+Purpose
+-------
+
+A primary goal of all the conferences and user groups that refer to this Code of Conduct is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status and religion (or lack thereof).
+
+This Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in our events to help us create safe and positive experiences for everyone.
+
+
+Open [Source/Culture/Tech] Citizenship
+--------------------------------------
+
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+
+Expected Behavior
+-----------------
+
+*	Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+*	Exercise consideration and respect in your speech and actions.
+*	Attempt collaboration before conflict.
+*	Refrain from demeaning, discriminatory, or harassing behavior and speech.
+*	Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+
+
+Unacceptable Behavior
+---------------------
+
+Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning speech or actions by any participant in our community online, at all related events and in one-on-one communications carried out in the context of community business. Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
+
+
+Consequences of Unacceptable Behavior
+-------------------------------------
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+
+If You Witness or Are Subject to Unacceptable Behavior
+------------------------------------------------------
+
+If you are subject to or witness unacceptable behavior,
+or have any other concerns, please notify a community organizer as soon as
+possible. You can find a list of organizers to contact for each of the
+supporters of this code of conduct at the bottom of this page. Additionally,
+community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+
+Addressing Grievances
+---------------------
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify one of the event organizers with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.
+
+
+Scope
+-----
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues—online and in-person—as well as in all one-on-one communications pertaining to community business.
+
+
+License and attribution
+-----------------------
+
+Berlin Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct), which is distributed under the same license.


### PR DESCRIPTION
This PR adds the code of conduct (EN) to the wheelmap project and is a subtask of https://github.com/sozialhelden/wheelmap/issues/17.