### PR TITLE
Fix asset paths

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -35,8 +35,7 @@ class Asset
   end
 
   def url
-    # @TODO use image_url when we moved to Rails 4
-    asset_paths.compute_public_path("/#{name}.zip", 'images', { protocol: :https })
+    asset_path("/#{name}.zip", { protocol: :https })
   end
 
   def file_name

--- a/spec/controllers/api/assets_controller_spec.rb
+++ b/spec/controllers/api/assets_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Api::AssetsController do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe 'index action' do
+
+    before do
+      get :index, :api_key => user.authentication_token
+    end
+
+    it 'returns http 200 success' do
+      expect(response.status).to eq 200
+    end
+
+    it 'returns valid json' do
+      expect {
+        JSON.parse(response.body)
+      }.to_not raise_error
+    end
+  end
+end

--- a/spec/controllers/api/assets_controller_spec.rb
+++ b/spec/controllers/api/assets_controller_spec.rb
@@ -5,6 +5,10 @@ describe Api::AssetsController do
 
   describe 'index action' do
 
+    def json_response
+      JSON.parse(response.body)
+    end
+
     before do
       get :index, :api_key => user.authentication_token
     end
@@ -15,7 +19,7 @@ describe Api::AssetsController do
 
     it 'returns valid json' do
       expect {
-        JSON.parse(response.body)
+        json_response
       }.to_not raise_error
     end
   end

--- a/spec/controllers/api/assets_controller_spec.rb
+++ b/spec/controllers/api/assets_controller_spec.rb
@@ -22,5 +22,23 @@ describe Api::AssetsController do
         json_response
       }.to_not raise_error
     end
+
+    describe 'the json response' do
+      let(:assets) { json_response['assets'] }
+
+      describe 'marker' do
+        let(:marker) { assets.find { |asset| asset['name'] == 'marker' }}
+        it 'has correct url' do
+          expect(marker['url']).to eq 'https://localhost:3000/marker.zip'
+        end
+      end
+
+      describe 'icons' do
+        let(:icons) { assets.find { |asset| asset['name'] == 'icons' }}
+        it 'has correct url' do
+          expect(icons['url']).to eq 'https://localhost:3000/icons.zip'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This fix is related to #293.
The `Api::AssetsController` didn't have any tests so we didn't notice that it uses methods which have been removed in Rails 4.0.