### PR TITLE
Enable asset compression via uglifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Wheelmap::Application.configure do
   # @TODO Enable compressors and find alternative for :yui
   # Compress CSS and JS faster in production
   # config.assets.css_compressor = :yui
-  # config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -16,6 +16,7 @@ Wheelmap::Application.configure do
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
+  config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = false


### PR DESCRIPTION
This PR reenables JavaScript asset compression for staging and production. 