### PR TITLE
Remove unused ember from to be precompiled list.

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,5 +17,5 @@ Rails.application.config.assets.precompile += ['application.js']
 Rails.application.config.assets.precompile += %w( relaunch.css relaunch_ie.css screen.css node.css nodes.css search.css react-select.css)
 
 # Precompile additional assets for assets pipeline (/assets/javascripts)
-Rails.application.config.assets.precompile += %w( relaunch.js modernizr.js search.js nodes.js ember.js ember-data.js app.js test.js)
+Rails.application.config.assets.precompile += %w( relaunch.js modernizr.js search.js nodes.js app.js test.js)
 Rails.application.config.assets.precompile += %w( i18n/*.js react-application.js )


### PR DESCRIPTION
Ember is never used standalone but always required from manifest files. This PR removes `ember.js` and `ember-data.js` from the precompile list, which further improves our asset precompile on deployment.