### PR TITLE
Fix missing key by changing from `community_center` to `community_centre`

### DIFF
--- a/config/locales/de/categories.yml
+++ b/config/locales/de/categories.yml
@@ -70,7 +70,7 @@ de:
         brothel: Bordell
         casino: Spielcasino
         cinema: Kino
-        community_center: "Stadthalle / Gemeindezentrum"
+        community_centre: "Stadthalle / Gemeindezentrum"
         gallery: Galerie
         massage: "Massage-Studio"
         nightclub: Nachtclub


### PR DESCRIPTION
This PR fixes the error `translation missing: de.poi.name.leisure.community_centre` on:

- staging.wheelmap.org/node_types
- wheelmap.org/node_types

Fixes partly issue: #282