### PR TITLE
Fix available locales look up in i18n instead of I18n

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Wheelmap
     # Use all locales that we have translations when not in production
     Dir.glob(Rails.root.join('config', 'locales', '*')).each do |directory|
       locale = File.basename(directory).to_sym
-      config.i18n.available_locales << locale unless I18n.available_locales.include?(locale)
+      config.i18n.available_locales << locale unless config.i18n.available_locales.include?(locale)
     end
 
  #   config.middleware.use(Rack::RequestLogger)


### PR DESCRIPTION
When trying to run rake tasks that invoke locales, we get following error in development.

```
rake aborted!
I18n::ArgumentError: Valid locales: de, ar, bg, ca, da, el, fa, fi, fy, hi, is, it, ja, ko, lt, lv, nb, nn, no, nqo, pl, pt, pt_BR, pt_PT, ro_RO, ru, sk, sq_AL, sv, tlh, tr, uk, vi, vi_VN, zh_TW - Given Locales: en
```

We fixed the available locales, for some reasons the ":en" locale couldn't be found.

