### PR TITLE
Remove x-frame-options header from iframe embeds response

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -3,6 +3,7 @@ class WidgetsController < ApplicationController
 
   before_filter :authenticate_user!, :only => [:update]
   before_filter :authenticate_with_api_key, :only => [:update, :embed]
+  after_action :allow_iframe, only: :embed
 
   def embed
     if params[:key].nil? || @widget
@@ -33,5 +34,11 @@ class WidgetsController < ApplicationController
     api_key = params[:key] || request.headers["X-API-KEY"]
     user    = api_key && User.find_by_api_key(api_key)
     @widget = user ? user.widget : nil
+  end
+
+  private
+
+  def allow_iframe
+    response.headers['X-Frame-Options'] = 'ALLOW-ALL'
   end
 end

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -39,6 +39,6 @@ class WidgetsController < ApplicationController
   private
 
   def allow_iframe
-    response.headers['X-Frame-Options'] = 'ALLOW-ALL'
+    response.headers.except! 'X-Frame-Options'
   end
 end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -57,7 +57,7 @@ describe WidgetsController do
     end
 
     context "the response" do
-      it "has x-frame options allow-all" do
+      it "does not have x-frame-options header" do
         get :embed, :key => widget.user.api_key
         expect(response.headers.include?('X-Frame-Options')).to be_falsey
       end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -55,5 +55,12 @@ describe WidgetsController do
         expect(assigns(:widget)).to be_falsey
       end
     end
+
+    context "the response" do
+      it "has x-frame options allow-all" do
+        get :embed, :key => widget.user.api_key
+        expect(response.headers['X-Frame-Options']).to eq('ALLOW-ALL') 
+      end
+    end
   end
 end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -59,7 +59,7 @@ describe WidgetsController do
     context "the response" do
       it "has x-frame options allow-all" do
         get :embed, :key => widget.user.api_key
-        expect(response.headers['X-Frame-Options']).to eq('ALLOW-ALL') 
+        expect(response.headers.include?('X-Frame-Options')).to be_falsey
       end
     end
   end


### PR DESCRIPTION
This PR fixes the broken embedding of iframes by removing the x-frame-options header from http-responses.