### PR TITLE
Add alert message to node photo upload.

### DIFF
--- a/app/assets/stylesheets/relaunch/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/relaunch/_bootstrap_variables.scss
@@ -230,9 +230,9 @@ $heroUnitLeadColor:               inherit !default;
 
 // Form states and alerts
 // -------------------------
-$warningText:             #c09853 !default;
+$warningText:             darken(#c09853, 10%) !default;
 $warningBackground:       #fcf8e3 !default;
-$warningBorder:           darken(adjust-hue($warningBackground, -10), 3%) !default;
+$warningBorder:           darken(adjust-hue($warningBackground, -10), 10%) !default;
 
 $errorText:               #b94a48 !default;
 $errorBackground:         #f2dede !default;

--- a/app/assets/stylesheets/relaunch/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/relaunch/_bootstrap_variables.scss
@@ -230,7 +230,7 @@ $heroUnitLeadColor:               inherit !default;
 
 // Form states and alerts
 // -------------------------
-$warningText:             darken(#c09853, 10%) !default;
+$warningText:             darken(#c09853, 20%) !default;
 $warningBackground:       #fcf8e3 !default;
 $warningBorder:           darken(adjust-hue($warningBackground, -10), 10%) !default;
 

--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -2,7 +2,7 @@
   %h2=t('.photos_of_this_place')
   - if user_signed_in? and current_user.terms?
     .alert.alert-icon
-      = fa_icon "exclamation"
+      = fa_icon 'exclamation-sign'
       = t('.alert')
       = link_to(t('.more_infos'), I18n.locale == :de ? '//community.wheelmap.org/haufig-gestellte-fragen/warum-soll-ich-bilder-zu-einem-ort-hochladen-wie-sollen-sie-aussehen/' : '//community.wheelmap.org/en/haufig-gestellte-fragen/why-should-i-upload-photos-to-a-place-how-should-they-look-like/', target: '_blank')
   =semantic_form_for([@node, Photo.new], url: node_photos_url(@node), html: { class: 'node-photo-dropzone', id: 'node-photo-dropzone', multipart: true }) do |form|

--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -4,7 +4,6 @@
     .alert.alert-icon
       = fa_icon 'exclamation-sign'
       = t('.alert')
-      = link_to(t('.more_infos'), I18n.locale == :de ? '//community.wheelmap.org/haufig-gestellte-fragen/warum-soll-ich-bilder-zu-einem-ort-hochladen-wie-sollen-sie-aussehen/' : '//community.wheelmap.org/en/haufig-gestellte-fragen/why-should-i-upload-photos-to-a-place-how-should-they-look-like/', target: '_blank')
   =semantic_form_for([@node, Photo.new], url: node_photos_url(@node), html: { class: 'node-photo-dropzone', id: 'node-photo-dropzone', multipart: true }) do |form|
     %ul
       = list_of(node_photos.photos.reject{|photo| photo.new_record?}) do |photo|

--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -1,6 +1,6 @@
 %section.node-photos
   %h2=t('.photos_of_this_place')
-  - if user_signed_in? and current_user.terms?
+  - if user_signed_in? && current_user.terms?
     .alert.alert-icon
       = fa_icon 'exclamation-sign'
       = t('.alert')

--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -1,5 +1,10 @@
 %section.node-photos
   %h2=t('.photos_of_this_place')
+  - if user_signed_in? and current_user.terms?
+    .alert.alert-icon
+      = fa_icon "exclamation"
+      = t('.alert')
+      = link_to(t('.more_infos'), I18n.locale == :de ? '//community.wheelmap.org/haufig-gestellte-fragen/warum-soll-ich-bilder-zu-einem-ort-hochladen-wie-sollen-sie-aussehen/' : '//community.wheelmap.org/en/haufig-gestellte-fragen/why-should-i-upload-photos-to-a-place-how-should-they-look-like/', target: '_blank')
   =semantic_form_for([@node, Photo.new], url: node_photos_url(@node), html: { class: 'node-photo-dropzone', id: 'node-photo-dropzone', multipart: true }) do |form|
     %ul
       = list_of(node_photos.photos.reject{|photo| photo.new_record?}) do |photo|

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -88,7 +88,6 @@ de:
       photos_of_this_place: 'Fotos von diesem Ort:'
       upload: Hochladen
       alert: "Bitte beachte: Auf dem Foto sollte der Eingangsbereich des Ortes gut zu erkennen sein. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Wie breit ist die Tür? Das Foto muss das Format JPG oder PNG haben. Die maximale Größe eines Fotos darf 10 MB nicht überschreiten."
-      more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Ähnliche Orte: %{name}'
     node_status:

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -87,7 +87,7 @@ de:
       add: Hinzufügen
       photos_of_this_place: 'Fotos von diesem Ort:'
       upload: Hochladen
-      alert: "Deshalb ist es wichtig, dass auf den Fotos der Eingangsbereich gut zu erkennen ist. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Ist die Tür breit genug?"
+      alert: "Bitte beachte: Auf dem Foto sollte der Eingangsbereich des Ortes gut zu erkennen sein. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Wie breit ist die Tür? Das Foto muss das Format JPG oder PNG haben. Die maximale Größe eines Fotos darf 10 MB nicht überschreiten."
       more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Ähnliche Orte: %{name}'

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -87,6 +87,8 @@ de:
       add: Hinzufügen
       photos_of_this_place: 'Fotos von diesem Ort:'
       upload: Hochladen
+      alert: "Deshalb ist es wichtig, dass auf den Fotos der Eingangsbereich gut zu erkennen ist. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Ist die Tür breit genug?"
+      more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Ähnliche Orte: %{name}'
     node_status:

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -88,6 +88,8 @@ en:
       add: Add
       photos_of_this_place: 'Photos of this place:'
       upload: Upload
+      alert: "Deshalb ist es wichtig, dass auf den Fotos der Eingangsbereich gut zu erkennen ist. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Ist die Tür breit genug?"
+      more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Similar places: %{name}'
     node_status:

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -88,7 +88,7 @@ en:
       add: Add
       photos_of_this_place: 'Photos of this place:'
       upload: Upload
-      alert: "Deshalb ist es wichtig, dass auf den Fotos der Eingangsbereich gut zu erkennen ist. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Ist die Tür breit genug?"
+      alert: "Please note: The entrance should be clearly visible in the photo in order to show the following: Are there steps at the entrance? Approximately how high is the step? How wide is the door? The photograph must be in a JPG or PNG format. It should not be larger than 10 MB."
       more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Similar places: %{name}'

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -89,7 +89,6 @@ en:
       photos_of_this_place: 'Photos of this place:'
       upload: Upload
       alert: "Please note: The entrance should be clearly visible in the photo in order to show the following: Are there steps at the entrance? Approximately how high is the step? How wide is the door? The photograph must be in a JPG or PNG format. It should not be larger than 10 MB."
-      more_infos: 'Mehr Infos'
     node_similar:
       similar: 'Similar places: %{name}'
     node_status:


### PR DESCRIPTION
Fixes #314.

It has not the best styling, because I didn't want to add another customized style for a often used element like an alert message. Something we should simplify, clean and match in future releases. Never the less should work fine for now.

<img width="1206" alt="screenshot 2016-07-12 12 41 30" src="https://cloud.githubusercontent.com/assets/1609692/16764446/8049cd28-482e-11e6-896f-e430cbe19575.png">

Texts and first translations will be provided by @Svenyo I guess. 

cc @holgerd