### PR TITLE
Adjust production logger settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,8 +42,7 @@ Wheelmap::Application.configure do
   # See everything in the log (default is :info)
   config.log_level = :info
 
-  # Use a different logger for distributed setups
-  # config.logger = SyslogLogger.new
+  config.logger = Logger.new('log/production.log', 3, 1073741824) # 1GB
 
   # Use a different cache store in production
   # default is:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Wheelmap::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new


### PR DESCRIPTION
This PR changes logging settings for the production environment:
- it sets the log level explicitly to ` info`
- it keeps 3 files à 1GB at maximum
