### PR TITLE
Read mail credentials from secrets yml

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,8 +75,8 @@ Wheelmap::Application.configure do
     :port           => 25,
     :domain         => 'wheelmap.org',
     :authentication => :login,
-    :user_name      => ENV['gmail_user'],
-    :password       => ENV['gmail_password']
+    :user_name      => Rails.application.secrets.gmail_user,
+    :password       => Rails.application.secrets.gmail_password
 
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,8 +75,8 @@ Wheelmap::Application.configure do
     :port           => 25,
     :domain         => 'wheelmap.org',
     :authentication => :login,
-    :user_name      => Rails.application.secrets.gmail_user,
-    :password       => Rails.application.secrets.gmail_password
+    :user_name      => Rails.application.secrets.mail_user,
+    :password       => Rails.application.secrets.mail_password
 
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -71,8 +71,8 @@ Wheelmap::Application.configure do
     :port           => 25,
     :domain         => 'wheelmap.org',
     :authentication => :login,
-    :user_name      => Rails.application.secrets.gmail_user,
-    :password       => Rails.application.secrets.gmail_password
+    :user_name      => Rails.application.secrets.mail_user,
+    :password       => Rails.application.secrets.mail_password
 
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -71,8 +71,8 @@ Wheelmap::Application.configure do
     :port           => 25,
     :domain         => 'wheelmap.org',
     :authentication => :login,
-    :user_name      => ENV['gmail_user'],
-    :password       => ENV['gmail_password']
+    :user_name      => Rails.application.secrets.gmail_user,
+    :password       => Rails.application.secrets.gmail_password
 
   }
 

--- a/config/secrets.sample.yml
+++ b/config/secrets.sample.yml
@@ -12,8 +12,8 @@
 
 development:
   secret_key_base: "56b897c9234129cae76f7c1f5341e9816a8c88b884cea4219d8df1509a4c8c1e5e946a0f077d66f64fc203e53cece93e5f221f2c1cfdbe1b8f034fd525c55a280"
-  gmail_username: "gmail_user"
-  gmail_password: "gmail_password"
+  mail_username: "mail_user"
+  mail_password: "mail_password"
   airbrake_api_key: "airbrake_api_key"
 
 test:


### PR DESCRIPTION
This PR fixes the problem that mail could not be delivered because credentials where missing. This happened due to the change from Rails 4.0 to Rails 4.1 where credentials where moved to the `secrets.yml`. Credentials based in the `secrets.yml` need to be fetched via `Rails.application.secrets` instead of using `ENV`.
This fixes #317 and #318