### PR TITLE
Fix routing error for icons on node_types page

### DIFF
--- a/app/views/node_types/_node_type.html.haml
+++ b/app/views/node_types/_node_type.html.haml
@@ -4,6 +4,6 @@
   %td=image_tag("/marker/limited/#{node_type.icon}", :size => '32x37')
   %td=image_tag("/marker/no/#{node_type.icon}", :size => '32x37')
   %td=image_tag("/marker/unknown/#{node_type.icon}", :size => '32x37')
-  %td=image_tag("/icons/#{node_type.icon}", :size => '22x22')
+  %td=image_tag("/assets/icons/#{node_type.icon}", :size => '22x22')
   %td=link_to "#{node_type.osm_key}=#{node_type.osm_value}", "http://wiki.openstreetmap.org/wiki/Tag:#{node_type.osm_key}%3D#{node_type.osm_value}"
   %td=number_with_delimiter(node_type.pois.count)

--- a/app/views/node_types/_node_type.html.haml
+++ b/app/views/node_types/_node_type.html.haml
@@ -1,9 +1,5 @@
 %tr
   %td=node_type.localized_name
-  %td=image_tag("/marker/yes/#{node_type.icon}", :size => '32x37')
-  %td=image_tag("/marker/limited/#{node_type.icon}", :size => '32x37')
-  %td=image_tag("/marker/no/#{node_type.icon}", :size => '32x37')
-  %td=image_tag("/marker/unknown/#{node_type.icon}", :size => '32x37')
   %td=image_tag("/assets/icons/#{node_type.icon}", :size => '22x22')
   %td=link_to "#{node_type.osm_key}=#{node_type.osm_value}", "http://wiki.openstreetmap.org/wiki/Tag:#{node_type.osm_key}%3D#{node_type.osm_value}"
   %td=number_with_delimiter(node_type.pois.count)

--- a/app/views/node_types/index.html.haml
+++ b/app/views/node_types/index.html.haml
@@ -1,11 +1,7 @@
 %h1 Node Types
-%table
+%table{style: 'width: 100%'}
   %tr
     %th=t('formtastic.labels.name')
-    %th=t('wheelchairstatus.yes')
-    %th=t('wheelchairstatus.limited')
-    %th=t('wheelchairstatus.no')
-    %th=t('wheelchairstatus.unknown')
     %th='Icon'
     %th='Key - Value'
     %th='Amount'


### PR DESCRIPTION
On **Google Chrome** the icons were broken while **Firebox** did not display them at all, please see #329 for details. This PR fixes that broken icon pipeline and is already deployed on staging for review. 

**Open task:**
Optimize the column widths => we will create a separate PR for this.

![00000125](https://cloud.githubusercontent.com/assets/4077916/16958067/48261260-4ddf-11e6-9e58-c39e9515adf6.png)