### PR TITLE
Fix admin region detail page

### DIFF
--- a/app/admin/region.rb
+++ b/app/admin/region.rb
@@ -5,6 +5,10 @@ ActiveAdmin.register Region do
   filter :updated_at
 
   controller do
+    def find_resource
+      Region.find_by(name: params[:id])
+    end
+
     def update
       region = resource
       region.update_attributes(params[:region])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -208,3 +208,6 @@ node_types = NodeType.create([
 
 Region.delete_all
 Region.connection.execute('ALTER TABLE regions AUTO_INCREMENT=1')
+
+berlin_grenze = RGeo::Cartesian.factory.parse_wkt "POLYGON ((10 10, 110 10, 110 110, 10 110))"
+Region.create(name: 'berlin', grenze: berlin_grenze)


### PR DESCRIPTION
PR for #335 

This fixes the broken Region lookup in the Region Admin section. Before it tried to fetch the region by id but the client sent the region name instead of its id. This is now fixed by using a custom `find_resource` method.  