### PR TITLE
Fix region not found in landing pages

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -11,10 +11,10 @@ class LandingPagesController < ApplicationController
   protected
 
   def load_region
-    @region = Region.find_by(name: params[:region_id])
+    @region = Region.find_by!(name: params[:region_id])
   rescue ActiveRecord::RecordNotFound
     @message = "Could not find region #{params[:region_id]}"
-    render :template => 'shared/error', :status => 400
+    render :template => 'shared/error', :status => 404
   end
 
   def load_status

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -24,9 +24,10 @@ class LandingPagesController < ApplicationController
   end
 
   def load_type
-    @node_type = NodeType.find_by_identifier(params[:node_type_id])
+    @node_type = NodeType.find_by!(identifier: params[:node_type_id])
+  rescue ActiveRecord::RecordNotFound
     @message = "Could not find type #{params[:node_type_id]}"
-    render :template => 'shared/error', :status => 400 unless @node_type
+    render :template => 'shared/error', :status => 404
   end
 
 end

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -11,9 +11,10 @@ class LandingPagesController < ApplicationController
   protected
 
   def load_region
-    @region = Region.find params[:region_id] rescue nil
+    @region = Region.find(params[:region_id])
+  rescue ActiveRecord::RecordNotFound
     @message = "Could not find region #{params[:region_id]}"
-    render :template => 'shared/error', :status => 400 unless @region
+    render :template => 'shared/error', :status => 400
   end
 
   def load_status

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -11,7 +11,7 @@ class LandingPagesController < ApplicationController
   protected
 
   def load_region
-    @region = Region.find(params[:region_id])
+    @region = Region.find_by(name: params[:region_id])
   rescue ActiveRecord::RecordNotFound
     @message = "Could not find region #{params[:region_id]}"
     render :template => 'shared/error', :status => 400

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -20,7 +20,7 @@ class LandingPagesController < ApplicationController
   def load_status
     @status = Poi::WHEELCHAIR_STATUS_VALUES[params[:wheelchair].to_sym]
     @message = "Could not find status #{params[:wheelchair]}"
-    render :template => 'shared/error', :status => 400 unless @status
+    render :template => 'shared/error', :status => 404 unless @status
   end
 
   def load_type

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -5,7 +5,7 @@ describe LandingPagesController do
   let(:node_type) { FactoryGirl::create(:node_type) }
   describe 'GET /index' do
     before do
-      get :index, page: 1, region_id: region.id, wheelchair: :unknown, node_type_id: node_type.identifier
+      get :index, page: 1, region_id: region.name, wheelchair: :unknown, node_type_id: node_type.identifier
     end
 
     it 'returns http 200 status' do

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -33,5 +33,15 @@ describe LandingPagesController do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'with invalid node type identifier' do
+      before do
+        get :index, page: 1, region_id: region.name, wheelchair: :unknown, node_type_id: 'something'
+      end
+
+      it 'returns http 404 status' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -4,12 +4,24 @@ describe LandingPagesController do
   let(:region)    { FactoryGirl::create(:region) }
   let(:node_type) { FactoryGirl::create(:node_type) }
   describe 'GET /index' do
-    before do
-      get :index, page: 1, region_id: region.name, wheelchair: :unknown, node_type_id: node_type.identifier
+    context 'with existing region' do
+      before do
+        get :index, page: 1, region_id: region.name, wheelchair: :unknown, node_type_id: node_type.identifier
+      end
+
+      it 'returns http 200 status' do
+        expect(response).to have_http_status(:success)
+      end
     end
 
-    it 'returns http 200 status' do
-      expect(response).to have_http_status(:success)
+    context 'with non existant region' do
+      before do
+        get :index, page: 1, region_id: 'hamburg', wheelchair: :unknown, node_type_id: node_type.identifier
+      end
+
+      it 'returns http 404 status' do
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 end

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -23,5 +23,15 @@ describe LandingPagesController do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'with invalid wheelchair value' do
+      before do
+        get :index, page: 1, region_id: region.name, wheelchair: :something, node_type_id: node_type.identifier
+      end
+
+      it 'returns http 404 status' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end


### PR DESCRIPTION
PR for #335 

This fixes the 'Could not find region xyz' problem on `http://wheelmap.org/map/berlin/theatre/wheelchair/yes`. The problem here was that it attempted to load the region by id but where the name was passed instead. It now queries the region correctly by name and also returns a 404 if it was not found. Before it returned a HTTP 400 error which was not adequate in this situation.