### PR TITLE
Add map zoom alert.

### DIFF
--- a/app/assets/javascripts/i18n/ar.js
+++ b/app/assets/javascripts/i18n/ar.js
@@ -839,7 +839,8 @@ I18n.translations["ar"] = I18n.extend((I18n.translations["ar"] || {}), {
         },
         "help": "هل وصول الكرسي المتحرك سهل؟ (بادر بتقديم المساعدة)",
         "more": "المزيد..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "كيف ؟",

--- a/app/assets/javascripts/i18n/bg.js
+++ b/app/assets/javascripts/i18n/bg.js
@@ -839,7 +839,8 @@ I18n.translations["bg"] = I18n.extend((I18n.translations["bg"] || {}), {
         },
         "help": "Достъпно за инвалидни колички? (Помощ)",
         "more": "повече..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Как?",

--- a/app/assets/javascripts/i18n/ca.js
+++ b/app/assets/javascripts/i18n/ca.js
@@ -850,7 +850,8 @@ I18n.translations["ca"] = I18n.extend((I18n.translations["ca"] || {}), {
         },
         "help": "Accessible amb cadira de rodes? (ajuda)",
         "more": "més..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Com?",

--- a/app/assets/javascripts/i18n/cs.js
+++ b/app/assets/javascripts/i18n/cs.js
@@ -847,7 +847,8 @@ I18n.translations["cs"] = I18n.extend((I18n.translations["cs"] || {}), {
         },
         "help": "Přístupné pro vozíčkáře? (Pomoc)",
         "more": "více ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Jak?",

--- a/app/assets/javascripts/i18n/da.js
+++ b/app/assets/javascripts/i18n/da.js
@@ -842,7 +842,8 @@ I18n.translations["da"] = I18n.extend((I18n.translations["da"] || {}), {
         },
         "help": "Kørestolstilgængeligt? (Hjælp)",
         "more": "mere ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Hvordan?",

--- a/app/assets/javascripts/i18n/de.js
+++ b/app/assets/javascripts/i18n/de.js
@@ -876,7 +876,8 @@ I18n.translations["de"] = I18n.extend((I18n.translations["de"] || {}), {
         },
         "help": "Rollstuhlgerecht? (Hilfe)",
         "more": "mehr ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Wie?",

--- a/app/assets/javascripts/i18n/el.js
+++ b/app/assets/javascripts/i18n/el.js
@@ -842,7 +842,8 @@ I18n.translations["el"] = I18n.extend((I18n.translations["el"] || {}), {
         },
         "help": "Δυνατότητα πρόσβασης με αναπηρική καρέκλα",
         "more": "περισσότερα ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Πώς;",

--- a/app/assets/javascripts/i18n/en.js
+++ b/app/assets/javascripts/i18n/en.js
@@ -839,7 +839,8 @@ I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/es.js
+++ b/app/assets/javascripts/i18n/es.js
@@ -850,7 +850,8 @@ I18n.translations["es"] = I18n.extend((I18n.translations["es"] || {}), {
         },
         "help": "¿Accesible para silla de ruedas? (Ayuda)",
         "more": "más ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "¿Cómo?",

--- a/app/assets/javascripts/i18n/fa.js
+++ b/app/assets/javascripts/i18n/fa.js
@@ -839,7 +839,8 @@ I18n.translations["fa"] = I18n.extend((I18n.translations["fa"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/fi.js
+++ b/app/assets/javascripts/i18n/fi.js
@@ -839,7 +839,8 @@ I18n.translations["fi"] = I18n.extend((I18n.translations["fi"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/fr.js
+++ b/app/assets/javascripts/i18n/fr.js
@@ -850,7 +850,8 @@ I18n.translations["fr"] = I18n.extend((I18n.translations["fr"] || {}), {
         },
         "help": "Accessible en fauteuil roulant ? (aide)",
         "more": "davantage.."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Comment ?",

--- a/app/assets/javascripts/i18n/fy.js
+++ b/app/assets/javascripts/i18n/fy.js
@@ -839,7 +839,8 @@ I18n.translations["fy"] = I18n.extend((I18n.translations["fy"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/hi.js
+++ b/app/assets/javascripts/i18n/hi.js
@@ -839,7 +839,8 @@ I18n.translations["hi"] = I18n.extend((I18n.translations["hi"] || {}), {
         },
         "help": "व्हीलचेयर सुलभ",
         "more": "और भी..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "कैसे",

--- a/app/assets/javascripts/i18n/hu.js
+++ b/app/assets/javascripts/i18n/hu.js
@@ -838,7 +838,8 @@ I18n.translations["hu"] = I18n.extend((I18n.translations["hu"] || {}), {
         },
         "help": "Kerekesszékkel akadálymentes? (Segítség)",
         "more": "több ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Hogyan?",

--- a/app/assets/javascripts/i18n/is.js
+++ b/app/assets/javascripts/i18n/is.js
@@ -839,7 +839,8 @@ I18n.translations["is"] = I18n.extend((I18n.translations["is"] || {}), {
         },
         "help": "Hjólastólaaðgengilegt? (Hjálp)",
         "more": "meiri ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/it.js
+++ b/app/assets/javascripts/i18n/it.js
@@ -850,7 +850,8 @@ I18n.translations["it"] = I18n.extend((I18n.translations["it"] || {}), {
         },
         "help": "Accessibile in sedia a rotelle? (Aiuto)",
         "more": "più ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Come?",

--- a/app/assets/javascripts/i18n/ja.js
+++ b/app/assets/javascripts/i18n/ja.js
@@ -882,7 +882,8 @@ I18n.translations["ja"] = I18n.extend((I18n.translations["ja"] || {}), {
         },
         "help": "車椅子で行けますか？ (ヘルプ)",
         "more": "詳細 ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "やり方は？",

--- a/app/assets/javascripts/i18n/ko.js
+++ b/app/assets/javascripts/i18n/ko.js
@@ -835,7 +835,8 @@ I18n.translations["ko"] = I18n.extend((I18n.translations["ko"] || {}), {
         },
         "help": "휠체어 접근성? (도움말)",
         "more": "자세히 ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "접근정보 등록은 어떻게?",

--- a/app/assets/javascripts/i18n/lt.js
+++ b/app/assets/javascripts/i18n/lt.js
@@ -840,7 +840,8 @@ I18n.translations["lt"] = I18n.extend((I18n.translations["lt"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "daugiau ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Kaip?",

--- a/app/assets/javascripts/i18n/lv.js
+++ b/app/assets/javascripts/i18n/lv.js
@@ -839,7 +839,8 @@ I18n.translations["lv"] = I18n.extend((I18n.translations["lv"] || {}), {
         },
         "help": "Pieejams ar ratiņkrēslu? (Palīdzība)",
         "more": "vairāk..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Kā?",

--- a/app/assets/javascripts/i18n/nb.js
+++ b/app/assets/javascripts/i18n/nb.js
@@ -839,7 +839,8 @@ I18n.translations["nb"] = I18n.extend((I18n.translations["nb"] || {}), {
         },
         "help": "Rullestoltilgjengelig? (hjelp)",
         "more": "Mer..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Hvordan?",

--- a/app/assets/javascripts/i18n/nl.js
+++ b/app/assets/javascripts/i18n/nl.js
@@ -840,7 +840,8 @@ I18n.translations["nl"] = I18n.extend((I18n.translations["nl"] || {}), {
         },
         "help": "rolstoel toegankelijk? (Hulp)",
         "more": "meer..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Hoe?",

--- a/app/assets/javascripts/i18n/nn.js
+++ b/app/assets/javascripts/i18n/nn.js
@@ -839,7 +839,8 @@ I18n.translations["nn"] = I18n.extend((I18n.translations["nn"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/no.js
+++ b/app/assets/javascripts/i18n/no.js
@@ -839,7 +839,8 @@ I18n.translations["no"] = I18n.extend((I18n.translations["no"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/nqo.js
+++ b/app/assets/javascripts/i18n/nqo.js
@@ -839,7 +839,8 @@ I18n.translations["nqo"] = I18n.extend((I18n.translations["nqo"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/pl.js
+++ b/app/assets/javascripts/i18n/pl.js
@@ -849,7 +849,8 @@ I18n.translations["pl"] = I18n.extend((I18n.translations["pl"] || {}), {
         },
         "help": "Dostępne dla osób na wózkach? (Pomoc)",
         "more": "więcej ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Jak?",

--- a/app/assets/javascripts/i18n/pt.js
+++ b/app/assets/javascripts/i18n/pt.js
@@ -847,7 +847,8 @@ I18n.translations["pt"] = I18n.extend((I18n.translations["pt"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/pt_BR.js
+++ b/app/assets/javascripts/i18n/pt_BR.js
@@ -842,7 +842,8 @@ I18n.translations["pt_BR"] = I18n.extend((I18n.translations["pt_BR"] || {}), {
         },
         "help": "Acessível a cadeirantes? (Ajuda)",
         "more": "mais ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Como?",

--- a/app/assets/javascripts/i18n/pt_PT.js
+++ b/app/assets/javascripts/i18n/pt_PT.js
@@ -842,7 +842,8 @@ I18n.translations["pt_PT"] = I18n.extend((I18n.translations["pt_PT"] || {}), {
         },
         "help": "Acessível a cadeiras de rodas? (Ajuda)",
         "more": "mais..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Como?",

--- a/app/assets/javascripts/i18n/ro.js
+++ b/app/assets/javascripts/i18n/ro.js
@@ -840,7 +840,8 @@ I18n.translations["ro"] = I18n.extend((I18n.translations["ro"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/ro_RO.js
+++ b/app/assets/javascripts/i18n/ro_RO.js
@@ -839,7 +839,8 @@ I18n.translations["ro_RO"] = I18n.extend((I18n.translations["ro_RO"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/ru.js
+++ b/app/assets/javascripts/i18n/ru.js
@@ -872,7 +872,8 @@ I18n.translations["ru"] = I18n.extend((I18n.translations["ru"] || {}), {
         },
         "help": "Доступно ли на кресле-коляске? (Справка)",
         "more": "Подробней ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Как?",

--- a/app/assets/javascripts/i18n/sk.js
+++ b/app/assets/javascripts/i18n/sk.js
@@ -842,7 +842,8 @@ I18n.translations["sk"] = I18n.extend((I18n.translations["sk"] || {}), {
         },
         "help": "Prístupné pre vozíčkarov? (Pomoc)",
         "more": "viac ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Ako?",

--- a/app/assets/javascripts/i18n/sq_AL.js
+++ b/app/assets/javascripts/i18n/sq_AL.js
@@ -839,7 +839,8 @@ I18n.translations["sq_AL"] = I18n.extend((I18n.translations["sq_AL"] || {}), {
         },
         "help": "E aksesueshme në karrige me rrota? (Ndihmë)",
         "more": "më shumë..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Si?",

--- a/app/assets/javascripts/i18n/sv.js
+++ b/app/assets/javascripts/i18n/sv.js
@@ -839,7 +839,8 @@ I18n.translations["sv"] = I18n.extend((I18n.translations["sv"] || {}), {
         },
         "help": "Rullstolstillgänglig? (Hjälp)",
         "more": "mera ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Hur?",

--- a/app/assets/javascripts/i18n/tlh.js
+++ b/app/assets/javascripts/i18n/tlh.js
@@ -839,7 +839,8 @@ I18n.translations["tlh"] = I18n.extend((I18n.translations["tlh"] || {}), {
         },
         "help": "naw'laH'a' rutlhquS? (QaH)",
         "more": "latlh ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/tr.js
+++ b/app/assets/javascripts/i18n/tr.js
@@ -843,7 +843,8 @@ I18n.translations["tr"] = I18n.extend((I18n.translations["tr"] || {}), {
         },
         "help": "Tekerlekli sandalye için ulaşılırmı? (Yardım)",
         "more": "daha fazla..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Nasıl?",

--- a/app/assets/javascripts/i18n/uk.js
+++ b/app/assets/javascripts/i18n/uk.js
@@ -872,7 +872,8 @@ I18n.translations["uk"] = I18n.extend((I18n.translations["uk"] || {}), {
         },
         "help": "Чи є доступ для людей на інвалідних візках? (Довідка)",
         "more": "детальніше ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "Як?",

--- a/app/assets/javascripts/i18n/vi.js
+++ b/app/assets/javascripts/i18n/vi.js
@@ -839,7 +839,8 @@ I18n.translations["vi"] = I18n.extend((I18n.translations["vi"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/vi_VN.js
+++ b/app/assets/javascripts/i18n/vi_VN.js
@@ -839,7 +839,8 @@ I18n.translations["vi_VN"] = I18n.extend((I18n.translations["vi_VN"] || {}), {
         },
         "help": "Wheelchair accessible? (Help)",
         "more": "more ..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "How?",

--- a/app/assets/javascripts/i18n/zh.js
+++ b/app/assets/javascripts/i18n/zh.js
@@ -839,7 +839,8 @@ I18n.translations["zh"] = I18n.extend((I18n.translations["zh"] || {}), {
         },
         "help": "轮椅可通过？（帮助）",
         "more": "更多..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "怎么样",

--- a/app/assets/javascripts/i18n/zh_TW.js
+++ b/app/assets/javascripts/i18n/zh_TW.js
@@ -842,7 +842,8 @@ I18n.translations["zh_TW"] = I18n.extend((I18n.translations["zh_TW"] || {}), {
         },
         "help": "輪椅無障礙？(說明)",
         "more": "更多..."
-      }
+      },
+      "zoom_alert": "Zoom in closer to see more places."
     }
   },
   "how?": "如何？",

--- a/app/assets/javascripts/views/map.view.js.coffee
+++ b/app/assets/javascripts/views/map.view.js.coffee
@@ -296,6 +296,7 @@ Wheelmap.MapView = EmberLeaflet.MapView.extend Wheelmap.LocateMixin, Wheelmap.Sp
 
     @get('layer')?.attributionControl.setPrefix('')
     @addEmbedLink()
+    @addZoomAlert()
 
   addEmbedLink: ->
     layer = @get('layer')
@@ -320,6 +321,41 @@ Wheelmap.MapView = EmberLeaflet.MapView.extend Wheelmap.LocateMixin, Wheelmap.Sp
       control
 
     embedLink.addTo(layer)
+
+  addZoomAlert: ->
+    layer = @get('layer')
+
+    unless layer? && !Ember.ENV.WIDGET
+      return
+
+    zoomAlert = L.control(position: 'topright')
+
+    zoomAlert.onAdd = (map)->
+      control = L.DomUtil.create('div', 'leaflet-zoom-alert leaflet-bar')
+
+      link = L.DomUtil.create('a', '', control)
+      link.href = '#'
+
+      icon = L.DomUtil.create('i', 'icon-exclamation-sign', link)
+      text = L.DomUtil.create('span', '', link)
+      text.innerHTML = ' Zoom in closer to see all places.'
+
+      toggleControl = ->
+        # Remove control when on highest zoom level.
+        maxZoom = layer.getZoom() == layer.getMaxZoom()
+        control.style.display = if maxZoom then 'none' else ''
+        return
+
+      layer.on('zoomend', toggleControl)
+      toggleControl()
+
+      link.addEventListener 'click', (event)->
+        event.preventDefault()
+        layer.setZoom(layer.getMaxZoom())
+
+      control
+
+    zoomAlert.addTo(layer)
 
   bboxDidChange: (->
     layer = @get('layer')

--- a/app/assets/javascripts/views/map.view.js.coffee
+++ b/app/assets/javascripts/views/map.view.js.coffee
@@ -328,7 +328,7 @@ Wheelmap.MapView = EmberLeaflet.MapView.extend Wheelmap.LocateMixin, Wheelmap.Sp
     unless layer? && !Ember.ENV.WIDGET
       return
 
-    zoomAlert = L.control(position: 'topright')
+    zoomAlert = L.control(position: 'topleft')
 
     zoomAlert.onAdd = (map)->
       control = L.DomUtil.create('div', 'leaflet-zoom-alert leaflet-bar')

--- a/app/assets/javascripts/views/map.view.js.coffee
+++ b/app/assets/javascripts/views/map.view.js.coffee
@@ -338,7 +338,7 @@ Wheelmap.MapView = EmberLeaflet.MapView.extend Wheelmap.LocateMixin, Wheelmap.Sp
 
       icon = L.DomUtil.create('i', 'icon-exclamation-sign', link)
       text = L.DomUtil.create('span', '', link)
-      text.innerHTML = ' Zoom in closer to see all places.'
+      text.innerHTML = " #{I18n.t('home.index.zoom_alert')}"
 
       toggleControl = ->
         # Remove control when on highest zoom level.

--- a/app/assets/javascripts/views/map.view.js.coffee
+++ b/app/assets/javascripts/views/map.view.js.coffee
@@ -351,7 +351,7 @@ Wheelmap.MapView = EmberLeaflet.MapView.extend Wheelmap.LocateMixin, Wheelmap.Sp
 
       link.addEventListener 'click', (event)->
         event.preventDefault()
-        layer.setZoom(layer.getMaxZoom())
+        layer.zoomIn()
 
       control
 

--- a/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
+++ b/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
@@ -57,3 +57,12 @@
     }
   }
 }
+
+.leaflet-zoom-alert {
+  position: absolute;
+  left: 36px; // margin + zoom button width
+
+  a {
+    white-space: nowrap;
+  }
+}

--- a/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
+++ b/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
@@ -44,14 +44,15 @@
   }
 }
 
-.leaflet-embed-link {
-  a,
-  a:hover {
+.leaflet-embed-link,
+.leaflet-zoom-alert {
+  a {
     padding: 0 8px;
     width: auto;
     background-color: rgba(255,255,255,0.8);
 
     &:hover {
+      width: auto;
       background-color: #FFF;
     }
   }

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -45,6 +45,7 @@ en:
         lookup: Search for a specific place
         secondary_headline: 'Our traffic light system to mark the wheelchair accessibility of public places:'
       embed_link: Show on Wheelmap.org
+      zoom_alert: Zoom in closer to see more places.
   nodes:
     new:
       form:


### PR DESCRIPTION
Fixes #316.

![screenshot 2016-07-25 14 11 48](https://cloud.githubusercontent.com/assets/1609692/17100926/d85df640-5271-11e6-9d07-9e139c203183.png)

<img width="306" alt="screenshot 2016-07-25 14 12 04" src="https://cloud.githubusercontent.com/assets/1609692/17100929/da5ed6f8-5271-11e6-8866-52b50d740029.png">

When clicking on the message, the user get zoomed in to the maximum zoom level available. The message disappears as soon as he reaches this zoom level.

* [x] Fix position.
* [x] Use translations.
