### PR TITLE
Use English as default locale.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Wheelmap
     config.middleware.use(Rack::I18nLocaleSwitcher)
     config.i18n.fallbacks = true
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-    config.i18n.default_locale = :de
+    config.i18n.default_locale = :en
     config.i18n.enforce_available_locales = false
 
     config.i18n.available_locales = [:de]


### PR DESCRIPTION
Fixes #344.

This PR changes the default locale to English (previously German).

The only problem I can see is a user visting the page without a cookie and a previously stored locale. When he visits wheelmap.org/map he will probably see the page in English. I'm not quite sure how solid the switch on the locale HTTP header is though: https://github.com/sozialhelden/wheelmap/blob/02412ab4465790ed6ab1c63171561e0013c6aab9/lib/rack_i18n_locale_switcher.rb#L68-L79