### PR TITLE
Fix/login signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   include AuthenticateUserFromToken
 
   skip_before_filter :verify_authenticity_token, :only => :authenticate
+  skip_before_filter :check_user_email!, only: [:after_signup_edit, :after_signup_update]
 
   before_filter :authenticate_user!,        :except => [:authenticate, :signed_in]
   before_filter :authenticate_mobile_user,  :only => :authenticate

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,7 +72,6 @@ class UsersController < ApplicationController
       end
       redirect_to after_sign_in_path_for(:user)
     else
-      flash.now[:alert] = @user.errors.full_messages.to_sentence
       render :template => 'users/after_signup_edit'
     end
   end

--- a/app/views/users/after_signup_edit.html.haml
+++ b/app/views/users/after_signup_edit.html.haml
@@ -1,8 +1,8 @@
 .content.user-after-signup
-  = semantic_form_for @user, :url => after_signup_update_profile_path, :method => :put, :html => {:novalidate => '' } do |form|
+  = semantic_form_for @user, :url => after_signup_update_profile_path, :method => :put, :html => { :novalidate => '' } do |form|
     .row-fluid.mt10
       .span10.offset1
-        %h3=t('.welcome.headline')
+        %h3= t('.welcome.headline')
         = form.inputs do
           %p= t('.welcome.set_password_for_mobile')
 
@@ -13,8 +13,7 @@
           = form.input :first_time, :as => :hidden, :input_html => { :value => @user.encrypted_password.blank? ? '1' : '0' }
 
     = form.actions class:'form-actions' do
-      = link_to t('common.skip'), after_sign_in_path_for(:user), class: 'pull-left btn'
-      %input.small.update.btn#user_submit{:name => 'commit', :type => 'submit', :value => t('formtastic.labels.finish'), :style => 'display:inline', class: 'pull-right btn-primary', :'data-confirm' => t('devise.confirmations.send_instructions')}
+      %input.small.update.btn#user_submit{:name => 'commit', :type => 'submit', :value => t('formtastic.labels.finish'), :style => 'display:inline', class: 'pull-right btn-primary'}
 
 - content_for :javascript do
   = javascript_include_tag :search

--- a/config/locales/de/rails.yml
+++ b/config/locales/de/rails.yml
@@ -35,8 +35,6 @@ de:
       models:
         user:
           attributes:
-            email:
-              blank: "muss ausgefüllt werden, wenn ein Passwort gesetzt wird"
             privacy_policy:
               accepted: "müssen akzeptiert werden"
             terms:

--- a/config/locales/en/rails.yml
+++ b/config/locales/en/rails.yml
@@ -35,8 +35,6 @@ en:
       models:
         user:
           attributes:
-            email:
-              blank: "can't be blank if password is given"
             privacy_policy:
               accepted: "must be accepted"
             terms:


### PR DESCRIPTION
This PR tries to fix #176, #175, #179 and #181.

**What did change?**

* The user email address is mandatory now. If a user is logged in for the first time or did not set an email address yet, we **always** show him `after_signup_update` page to add a email address.<br />*This part is really critical I think. We need to be sure to force user to have a email address. There is a quite big opportunity users get angry or frustrated because they are forced to give data to us.*<br />*We also need to check if this has any implications for the apps on the mobile devices.*
* The user password was only needed so users were able to login via their mobile devices. As we refactored this process completely via an integrated WebView, I removed the password field completely.
* The `after_signup_update` view cannot be skipped anymore.
* I remove some of the duplicate flash messages and JavaScript alerts, which were shown when the user clicked on the submit button or reached the front page.

**What needs to be done?**

* [ ] Fix tests.

**Note:**

* I thought a while about making `after_signup_update` "beautiful again" and I decided to don't touch it. The problem is that we do not have any kind of Style Guide which can be applied here or was applied to every page on the platform. Adding once again another form style will lead to more and more CSS lines and a quite bloated Stylesheet. 