### PR TITLE
[WIP]: new deployment config

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -14,7 +14,7 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/bundler
 #   https://github.com/capistrano/rails
 #
-require 'capistrano/rbenv'
+#require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano/npm'
 require 'capistrano/rails/assets'

--- a/Capfile
+++ b/Capfile
@@ -16,7 +16,7 @@ require 'capistrano/deploy'
 #
 #require 'capistrano/rbenv'
 require 'capistrano/bundler'
-require 'capistrano/npm'
+#require 'capistrano/npm'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/deploytags'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     airbrake (4.3.6)
       builder
       multi_json
+    airbrussh (1.1.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     apipie-rails (0.3.6)
       json
     arbre (1.0.3)
@@ -111,15 +113,18 @@ GEM
     cacheable_flash (0.3.4)
       json
       stackable_flash (>= 0.0.7)
-    capistrano (3.4.0)
+    capistrano (3.6.1)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
+      sshkit (>= 1.9.0)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-deploytags (1.0.4)
       capistrano (>= 3.2.0)
+    capistrano-harrow (0.5.3)
     capistrano-npm (1.0.1)
       capistrano (>= 3.0.0)
     capistrano-rails (1.1.6)
@@ -339,7 +344,7 @@ GEM
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (3.2.0)
     newrelic_rpm (3.15.0.314)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -491,7 +496,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sshkit (1.9.0)
+    sshkit (1.11.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stackable_flash (0.0.7)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,13 +31,11 @@ set :linked_files, -> {
   end
 }
 
+
 set :bundle_roles, [:app, :worker]
-
-# Default value for :bundle_without is %w{development test}.join(' ')
 set :bundle_without, %w{ development test metrics deployment }.join(' ')
-
-# Default value for :bundle_jobs is: nil
 set :bundle_jobs, 4
+set :bundle_binstubs, -> { shared_path.join('bin') }
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
@@ -141,6 +139,6 @@ namespace :deploy do
     end
   end
 
-  after :finished, 'airbrake:deploy'
-  after :finished, 'newrelic:notice_deployment'
+#  after :finished, 'airbrake:deploy'
+#  after :finished, 'newrelic:notice_deployment'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,13 +23,7 @@ set :log_level, :debug
 set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, -> {
-  if [:app, :worker].include?(fetch(:role))
-    %w{ config/database.yml config/open_street_map.yml config/metrics.yml config/librato.yml config/newrelic.yml .env config/secrets.yml}
-  else
-    []
-  end
-}
+set :linked_files, %w{ config/database.yml config/open_street_map.yml config/metrics.yml config/librato.yml config/newrelic.yml .env config/secrets.yml}
 
 
 set :bundle_roles, [:app, :worker]
@@ -39,13 +33,7 @@ set :bundle_binstubs, -> { shared_path.join('bin') }
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, -> {
-  if [:app, :worker].include?(fetch(:role))
-    %w{ log tmp/var tmp/osmosis-working-dir tmp/cache tmp/sockets tmp/pids vendor/bundle public/system public/assets node_modules }
-  else
-    []
-  end
-}
+set :linked_dirs, %w{ log tmp/var tmp/osmosis-working-dir tmp/cache tmp/sockets tmp/pids vendor/bundle public/system public/assets node_modules }
 
 # Default value for keep_releases is 5
 set :keep_releases, 5
@@ -77,7 +65,7 @@ namespace :deploy do
       on roles(:asset) do
         # this needs to be done outside run_locally in order for host to exist
         remote_dir = "#{host.user}@#{host.hostname}:#{release_path}/public/assets/"
-
+        execute "mkdir -p #{release_path}/public/assets/"
         run_locally { execute "rsync -av --delete #{local_dir} #{remote_dir}" }
       end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -94,21 +94,21 @@ namespace :deploy do
     on roles(:app), in: :sequence, wait: 5 do
       # Your restart mechanism here, for example:
       # execute :touch, release_path.join('tmp/restart.txt')
-      sudo "systemctl restart unicorn.service"
+      sudo "systemctl restart webapp.service"
     end
   end
 
   desc 'Stopp application'
   task :stop do
     on roles(:app), in: :sequence, wait: 5 do
-      sudo "systemctl stop unicorn.service"
+      sudo "systemctl stop webapp.service"
     end
   end
 
   desc 'Start application'
   task :start do
     on roles(:app), in: :sequence, wait: 5 do
-      sudo "systemctl start unicorn.service"
+      sudo "systemctl start webapp.service"
     end
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,6 +67,12 @@ namespace :deploy do
         remote_dir = "#{host.user}@#{host.hostname}:#{release_path}/public/assets/"
         execute "mkdir -p #{release_path}/public/assets/"
         run_locally { execute "rsync -av --delete #{local_dir} #{remote_dir}" }
+
+        # stolen from https://github.com/capistrano/capistrano/blob/master/lib/capistrano/tasks/deploy.rake#L101
+        # we can't directly invoke the task since that runs on deploy roles only
+        tmp_current_path = release_path.parent.join(current_path.basename)
+        execute :ln, "-s", release_path, tmp_current_path
+        execute :mv, tmp_current_path, current_path.parent
       end
 
       # clean up

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :bundle_binstubs, -> { shared_path.join('bin') }
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, %w{ log tmp/var tmp/osmosis-working-dir tmp/cache tmp/sockets tmp/pids vendor/bundle public/system public/assets node_modules }
+set :linked_dirs, %w{ log tmp vendor/bundle public/system public/assets node_modules }
 
 # Default value for keep_releases is 5
 set :keep_releases, 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,28 +45,63 @@ set :rbenv_custom_path, '/opt/rbenv'
 # Default value for keep_releases is 5
 set :keep_releases, 5
 
+
+# Clear existing task so we can replace it rather than "add" to it.
+Rake::Task["deploy:compile_assets"].clear
+
 namespace :deploy do
+
+  desc 'Compile assets'
+  task :compile_assets => [:set_rails_env] do
+    # invoke 'deploy:assets:precompile'
+    invoke 'deploy:assets:precompile_local'
+    invoke 'deploy:assets:backup_manifest'
+  end
+
+  namespace :assets do
+
+    desc "Precompile assets locally and then rsync to web servers"
+    task :precompile_local do
+      # compile assets locally
+      run_locally do
+        execute "RAILS_ENV=#{fetch(:stage)} bundle exec rake assets:precompile"
+      end
+
+      # rsync to each server
+      local_dir = "./public/assets/"
+      on roles(:asset) do
+        # this needs to be done outside run_locally in order for host to exist
+        remote_dir = "#{host.user}@#{host.hostname}:#{release_path}/public/assets/"
+
+        run_locally { execute "rsync -av --delete #{local_dir} #{remote_dir}" }
+      end
+
+      # clean up
+      run_locally { execute "rm -rf #{local_dir}" }
+    end
+
+  end
 
   desc 'Restart application'
   task :restart do
     on roles(:app), in: :sequence, wait: 5 do
       # Your restart mechanism here, for example:
       # execute :touch, release_path.join('tmp/restart.txt')
-      sudo "/etc/init.d/unicorn_#{fetch(:stage)} upgrade"
+      sudo "systemctl restart unicorn.service"
     end
   end
 
   desc 'Stopp application'
   task :stop do
     on roles(:app), in: :sequence, wait: 5 do
-      sudo "/etc/init.d/unicorn_#{fetch(:stage)} stop"
+      sudo "systemctl stop unicorn.service"
     end
   end
 
   desc 'Start application'
   task :start do
     on roles(:app), in: :sequence, wait: 5 do
-      sudo "/etc/init.d/unicorn_#{fetch(:stage)} start"
+      sudo "systemctl start unicorn.service"
     end
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,15 @@ set :log_level, :debug
 set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{ config/database.yml config/open_street_map.yml config/metrics.yml config/librato.yml config/newrelic.yml .env config/secrets.yml}
+set :linked_files, -> {
+  if [:app, :worker].include?(fetch(:role))
+    %w{ config/database.yml config/open_street_map.yml config/metrics.yml config/librato.yml config/newrelic.yml .env config/secrets.yml}
+  else
+    []
+  end
+}
+
+set :bundle_roles, [:app, :worker]
 
 # Default value for :bundle_without is %w{development test}.join(' ')
 set :bundle_without, %w{ development test metrics deployment }.join(' ')
@@ -33,14 +41,13 @@ set :bundle_jobs, 4
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, %w{ log tmp/var tmp/osmosis-working-dir tmp/cache tmp/sockets tmp/pids vendor/bundle public/system public/assets node_modules }
-
-set :rbenv_type, :system # :user or :system, depends on your rbenv setup
-set :rbenv_ruby, '2.2.2'
-set :rbenv_custom_path, '/opt/rbenv'
-
-# Default value for default_env is {}
-# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+set :linked_dirs, -> {
+  if [:app, :worker].include?(fetch(:role))
+    %w{ log tmp/var tmp/osmosis-working-dir tmp/cache tmp/sockets tmp/pids vendor/bundle public/system public/assets node_modules }
+  else
+    []
+  end
+}
 
 # Default value for keep_releases is 5
 set :keep_releases, 5
@@ -67,7 +74,7 @@ namespace :deploy do
         execute "RAILS_ENV=#{fetch(:stage)} bundle exec rake assets:precompile"
       end
 
-      # rsync to each server
+      # rsync to asset server
       local_dir = "./public/assets/"
       on roles(:asset) do
         # this needs to be done outside run_locally in order for host to exist

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -26,11 +26,11 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 
-server 'app0.node.consul', user: 'deploy', roles: %w{app}, port: 22
-server 'app1.node.consul', user: 'deploy', roles: %w{app}, port: 22
-#server 'asset.node.consul', user: 'deploy', roles: %w{web}, port: 22
-#server 'worker.node.consul', user: 'deploy', roles: %w{worker}, port: 22
-#server 'mysql.node.consul', user: 'wheelmap', roles: %w{mysql}, port: 22
+server 'app0.node.production', user: 'deploy', roles: %w{app}, port: 22
+server 'app1.node.production', user: 'deploy', roles: %w{app}, port: 22
+server 'asset.node.production', user: 'deploy', roles: %w{web}, port: 22
+server 'worker.node.production', user: 'deploy', roles: %w{worker}, port: 22
+#server 'mysql.node.production', user: 'wheelmap', roles: %w{mysql}, port: 22
 
 # Custom SSH Options
 # ==================

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -28,7 +28,7 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 server 'app0.node.production', user: 'deploy', roles: %w{app}, port: 22
 server 'app1.node.production', user: 'deploy', roles: %w{app}, port: 22
-server 'asset.node.production', user: 'deploy', roles: %w{asset}, port: 22
+server 'asset.node.production', user: 'deploy', roles: %w{asset}, port: 22, :no_release => true
 server 'worker.node.production', user: 'deploy', roles: %w{worker}, port: 22
 #server 'mysql.node.production', user: 'wheelmap', roles: %w{mysql}, port: 22
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,7 @@ set :rails_env, "production" #added for delayed job
 set :stage, :production
 set :deploy_to, "/var/apps/#{fetch(:application)}/#{fetch(:stage)}"
 
-set :branch, :production
+set :branch, :"feature/infrastructure-rebuild/deployment"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 # Simple Role Syntax
@@ -15,10 +15,10 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 # is considered to be the first unless any hosts have the primary
 # property set.  Don't declare `role :all`, it's a meta role.
 
-role :app,    %w{176.9.63.170}
-role :web,    %w{176.9.63.170}
-role :db,     %w{176.9.63.170}
-role :worker, %w{176.9.63.170}
+#role :app,    %w{176.9.63.170}
+#role :web,    %w{176.9.63.170}
+#role :db,     %w{176.9.63.170}
+#role :worker, %w{176.9.63.170}
 
 # Extended Server Syntax
 # ======================
@@ -26,8 +26,10 @@ role :worker, %w{176.9.63.170}
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 
-server '176.9.63.170', user: 'rails', roles: %w{web app db worker}, port: 22022
-
+server 'app0.node.consul', user: 'deploy', roles: %w{web app}, port: 22
+server 'app1.node.consul', user: 'deploy', roles: %w{web app}, port: 22
+#server 'worker.node.consul', user: 'deploy', roles: %w{worker}, port: 22
+#server 'mysql.node.consul', user: 'wheelmap', roles: %w{mysql}, port: 22
 
 # Custom SSH Options
 # ==================
@@ -36,13 +38,13 @@ server '176.9.63.170', user: 'rails', roles: %w{web app db worker}, port: 22022
 #
 # Global options
 # --------------
-set :ssh_options, {
-  keys: %w(~/.ssh/wheelmap_rsa),
-  forward_agent: true,
-  config: true,
-  port: 22022
-  # auth_methods: %w(password)
-}
+#set :ssh_options, {
+#  keys: %w(~/.ssh/wheelmap_rsa),
+#  forward_agent: true,
+#  config: true,
+#  port: 22022
+#  # auth_methods: %w(password)
+#}
 #
 # And/or per server (overrides global)
 # ------------------------------------

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -26,8 +26,9 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 
-server 'app0.node.consul', user: 'deploy', roles: %w{web app}, port: 22
-server 'app1.node.consul', user: 'deploy', roles: %w{web app}, port: 22
+server 'app0.node.consul', user: 'deploy', roles: %w{app}, port: 22
+server 'app1.node.consul', user: 'deploy', roles: %w{app}, port: 22
+server 'asset.node.consul', user: 'deploy', roles: %w{web}, port: 22
 #server 'worker.node.consul', user: 'deploy', roles: %w{worker}, port: 22
 #server 'mysql.node.consul', user: 'wheelmap', roles: %w{mysql}, port: 22
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,7 +4,7 @@ set :delayed_job_args, "-p wheelmap_production"
 set :rails_env, "production" #added for delayed job
 
 set :stage, :production
-set :deploy_to, "/var/apps/#{fetch(:application)}/#{fetch(:stage)}"
+set :deploy_to, "/var/apps/#{fetch(:application)}/"
 
 set :branch, :"feature/infrastructure-rebuild/deployment"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -28,7 +28,7 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 server 'app0.node.consul', user: 'deploy', roles: %w{app}, port: 22
 server 'app1.node.consul', user: 'deploy', roles: %w{app}, port: 22
-server 'asset.node.consul', user: 'deploy', roles: %w{web}, port: 22
+#server 'asset.node.consul', user: 'deploy', roles: %w{web}, port: 22
 #server 'worker.node.consul', user: 'deploy', roles: %w{worker}, port: 22
 #server 'mysql.node.consul', user: 'wheelmap', roles: %w{mysql}, port: 22
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -28,7 +28,7 @@ set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 server 'app0.node.production', user: 'deploy', roles: %w{app}, port: 22
 server 'app1.node.production', user: 'deploy', roles: %w{app}, port: 22
-server 'asset.node.production', user: 'deploy', roles: %w{web}, port: 22
+server 'asset.node.production', user: 'deploy', roles: %w{asset}, port: 22
 server 'worker.node.production', user: 'deploy', roles: %w{worker}, port: 22
 #server 'mysql.node.production', user: 'wheelmap', roles: %w{mysql}, port: 22
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -2,9 +2,9 @@
 # Set environment to development unless something else is specified
 env = ENV["RAILS_ENV"] || "staging"
 
-worker_processes (env == 'production' ? 9 : 1)
-base_dir = "/var/apps/wheelmap/#{env}/current"
-shared_path = "/var/apps/wheelmap/#{env}/shared"
+worker_processes 4
+base_dir = "/var/apps/wheelmap/current"
+shared_path = "/var/apps/wheelmap/shared"
 working_directory base_dir
 
 # This loads the application in the master process before forking
@@ -27,15 +27,13 @@ end
 
 timeout (env == 'production' ? 300 : 30)
 
-# This is where we specify the socket.
-# We will point the upstream Nginx module to this socket later on
 listen 3000, :backlog => 1024
 
-pid "#{shared_path}/pids/unicorn.pid"
+pid = "#{shared_path}/pids/unicorn.pid"
 
-# Set the path of the log files inside the log folder of the testapp
-stdout_path "#{shared_path}/log/unicorn.stdout.log"
-stderr_path "#{shared_path}/log/unicorn.stderr.log"
+## Set the path of the log files inside the log folder of the testapp
+#stdout_path "#{shared_path}/log/unicorn.stdout.log"
+#stderr_path "#{shared_path}/log/unicorn.stderr.log"
 
 # The new check_client_connection option allows unicorn to detect
 # most disconnected local clients before potentially expensive

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -29,7 +29,7 @@ timeout (env == 'production' ? 300 : 30)
 
 listen 3000, :backlog => 1024
 
-pid = "#{shared_path}/pids/unicorn.pid"
+pid "#{shared_path}/pids/unicorn.pid"
 
 ## Set the path of the log files inside the log folder of the testapp
 #stdout_path "#{shared_path}/log/unicorn.stdout.log"

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -5,41 +5,27 @@ namespace :delayed_job do
   end
 
   def delayed_job_roles
-    fetch(:delayed_job_server_role, :app)
+    fetch(:delayed_job_server_role, :worker)
   end
 
   desc 'Stop the delayed_job process'
   task :stop do
     on roles(delayed_job_roles) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          sudo "/usr/bin/monit unmonitor delayed_job" rescue nil
-          execute :bundle, :exec, :'script/delayed_job', :stop
-        end
-      end
+      sudo "systemctl stop worker.service"
     end
   end
 
   desc 'Start the delayed_job process'
   task :start do
     on roles(delayed_job_roles) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, :'script/delayed_job', args, :start
-          sudo "/usr/bin/monit monitor delayed_job" rescue nil
-        end
-      end
+      sudo "systemctl start worker.service"
     end
   end
 
   desc 'Restart the delayed_job process'
   task :restart do
     on roles(delayed_job_roles) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, :'bin/delayed_job', args, :restart
-        end
-      end
+      sudo "systemctl restart worker.service"
     end
   end
 


### PR DESCRIPTION
add app servers, workers are still commented out. 

This deployment config properly attempts to deploy to app0/app1. It currently fails due to a missing database config.

It requires the following ssh config:

    Host wheelmap-jmp
      SendEnv GIT_*
      ForwardAgent yes
      Hostname 185.56.129.83
    
    Host *.node.production
      ForwardAgent yes
      ProxyCommand ssh wheelmap-jmp -W %h:%p

Name resolution for app0.node.consul will happen on the jumphost and since the jumphost is part of the consul cluster it will succeed.