### PR TITLE
Change links from `community` to `news`

### DIFF
--- a/app/assets/javascripts/views/node-popup.view.js.coffee
+++ b/app/assets/javascripts/views/node-popup.view.js.coffee
@@ -3,7 +3,7 @@ Wheelmap.NodePopupView = Ember.View.extend
   classNames: ['node-popup-view']
 
   aboutFaqLink: (()->
-    if I18n.locale == 'de' then '//community.wheelmap.org/about/faqs/' else '//community.wheelmap.org/en/faqs/'
+    if I18n.locale == 'de' then '//news.wheelmap.org/about/faqs/' else '//news.wheelmap.org/en/faqs/'
   ).property()
 
   linkTarget: (()->

--- a/app/assets/javascripts/views/node-popup.view.js.coffee
+++ b/app/assets/javascripts/views/node-popup.view.js.coffee
@@ -3,7 +3,7 @@ Wheelmap.NodePopupView = Ember.View.extend
   classNames: ['node-popup-view']
 
   aboutFaqLink: (()->
-    if I18n.locale == 'de' then '//news.wheelmap.org/about/faqs/' else '//news.wheelmap.org/en/faqs/'
+    if I18n.locale == 'de' then '//news.wheelmap.org/faq' else '//news.wheelmap.org/en/faq/'
   ).property()
 
   linkTarget: (()->

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,9 +50,9 @@ module ApplicationHelper
 
   def link_to_participate
     if I18n.locale == :de
-      link_to( t('how?'), "//community.wheelmap.org/mitmachen", :target => '_blank')
+      link_to( t('how?'), "//news.wheelmap.org/mitmachen", :target => '_blank')
     else
-      link_to( t('how?'), "//community.wheelmap.org/en/participate", :target => '_blank')
+      link_to( t('how?'), "//news.wheelmap.org/en/participate", :target => '_blank')
     end
   end
 
@@ -97,57 +97,57 @@ module ApplicationHelper
 
   def community_blog_url
     if I18n.locale == :de
-      "//community.wheelmap.org/blog/"
+      "//news.wheelmap.org/blog/"
     else
-      "//community.wheelmap.org/en/blog/"
+      "//news.wheelmap.org/en/blog/"
     end
   end
 
   def community_press_url
     if I18n.locale == :de
-      "//community.wheelmap.org/about/presse/"
+      "//news.wheelmap.org/about/presse/"
     else
-      "//community.wheelmap.org/en/about/press/"
+      "//news.wheelmap.org/en/about/press/"
     end
   end
 
   def community_contact_url
     if I18n.locale == :de
-      "//community.wheelmap.org/kontakt/"
+      "//news.wheelmap.org/kontakt/"
     else
-      "//community.wheelmap.org/en/contact/"
+      "//news.wheelmap.org/en/contact/"
     end
   end
 
   def community_projects_url
     if I18n.locale == :de
-      "//community.wheelmap.org/projekte/"
+      "//news.wheelmap.org/projekte/"
     else
-      "//community.wheelmap.org/en/get-engaged/"
+      "//news.wheelmap.org/en/get-engaged/"
     end
   end
 
   def community_imprint_url
     if I18n.locale == :de
-      "//community.wheelmap.org/impressum/"
+      "//news.wheelmap.org/impressum/"
     else
-      "//community.wheelmap.org/en/imprint/"
+      "//news.wheelmap.org/en/imprint/"
     end
   end
 
   def community_about_url
     if I18n.locale == :de
-      "//community.wheelmap.org/about/"
+      "//news.wheelmap.org/about/"
     else
-      "//community.wheelmap.org/en/about/"
+      "//news.wheelmap.org/en/about/"
     end
   end
 
   def community_newsletter_url
     if I18n.locale == :de
-      "//community.wheelmap.org/newsletter/"
+      "//news.wheelmap.org/newsletter/"
     else
-      "//community.wheelmap.org/newsletter-2/"
+      "//news.wheelmap.org/newsletter-2/"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,7 +107,7 @@ module ApplicationHelper
     if I18n.locale == :de
       "//news.wheelmap.org/presse/"
     else
-      "//news.wheelmap.org/en/press"
+      "//news.wheelmap.org/en/press/"
     end
   end
 
@@ -137,17 +137,17 @@ module ApplicationHelper
 
   def community_about_url
     if I18n.locale == :de
-      "//news.wheelmap.org/about/"
+      "//news.wheelmap.org/faq"
     else
-      "//news.wheelmap.org/en/about/"
+      "//news.wheelmap.org/en/faq"
     end
   end
 
   def community_newsletter_url
     if I18n.locale == :de
-      "//news.wheelmap.org/newsletter/"
+      "//news.wheelmap.org/kontakt/"
     else
-      "//news.wheelmap.org/newsletter-2/"
+      "//news.wheelmap.org/contact/"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,9 +50,9 @@ module ApplicationHelper
 
   def link_to_participate
     if I18n.locale == :de
-      link_to( t('how?'), "//news.wheelmap.org/mitmachen", :target => '_blank')
+      link_to( t('how?'), "//news.wheelmap.org/botschafter-werden/", :target => '_blank')
     else
-      link_to( t('how?'), "//news.wheelmap.org/en/participate", :target => '_blank')
+      link_to( t('how?'), "//news.wheelmap.org/en/become-a-wheelmap-ambassador/", :target => '_blank')
     end
   end
 
@@ -97,17 +97,17 @@ module ApplicationHelper
 
   def community_blog_url
     if I18n.locale == :de
-      "//news.wheelmap.org/blog/"
+      "//news.wheelmap.org/news/"
     else
-      "//news.wheelmap.org/en/blog/"
+      "//news.wheelmap.org/en/news/"
     end
   end
 
   def community_press_url
     if I18n.locale == :de
-      "//news.wheelmap.org/about/presse/"
+      "//news.wheelmap.org/presse/"
     else
-      "//news.wheelmap.org/en/about/press/"
+      "//news.wheelmap.org/en/press"
     end
   end
 
@@ -121,9 +121,9 @@ module ApplicationHelper
 
   def community_projects_url
     if I18n.locale == :de
-      "//news.wheelmap.org/projekte/"
+      "//news.wheelmap.org/wheelmap-botschafter-werden/"
     else
-      "//news.wheelmap.org/en/get-engaged/"
+      "//news.wheelmap.org/en/become-a-wheelmap-ambassador/"
     end
   end
 

--- a/app/views/nodes/_node_faq.html.haml
+++ b/app/views/nodes/_node_faq.html.haml
@@ -6,7 +6,7 @@
   .node-report-accordion.dropdown-accordion
     %header
       .pull-right
-        = link_to('FAQ', I18n.locale == :de ? '//community.wheelmap.org/about/faqs/' : '//community.wheelmap.org/en/faqs/', class: 'btn btn-mini', target: '_blank')
+        = link_to('FAQ', I18n.locale == :de ? '//news.wheelmap.org/about/faqs/' : '//news.wheelmap.org/en/faqs/', class: 'btn btn-mini', target: '_blank')
         = mail_to('bugs@wheelmap.org', content_tag(:i, '', class: 'icon-envelope-alt'), class: 'btn btn-mini', encode: :hex, subject: I18n.t('models.node.mail.subject', headline: @node.headline), body: I18n.t('models.node.mail.body', url: node_url(@node)))
       = t('faq.headline')
     - t('faq.questions').size.times do |i|

--- a/app/views/nodes/_node_faq.html.haml
+++ b/app/views/nodes/_node_faq.html.haml
@@ -6,7 +6,7 @@
   .node-report-accordion.dropdown-accordion
     %header
       .pull-right
-        = link_to('FAQ', I18n.locale == :de ? '//news.wheelmap.org/about/faqs/' : '//news.wheelmap.org/en/faqs/', class: 'btn btn-mini', target: '_blank')
+        = link_to('FAQ', I18n.locale == :de ? '//news.wheelmap.org/faq/' : '//news.wheelmap.org/en/faq/', class: 'btn btn-mini', target: '_blank')
         = mail_to('bugs@wheelmap.org', content_tag(:i, '', class: 'icon-envelope-alt'), class: 'btn btn-mini', encode: :hex, subject: I18n.t('models.node.mail.subject', headline: @node.headline), body: I18n.t('models.node.mail.body', url: node_url(@node)))
       = t('faq.headline')
     - t('faq.questions').size.times do |i|

--- a/app/views/relaunch/_footer.html.haml
+++ b/app/views/relaunch/_footer.html.haml
@@ -18,9 +18,9 @@
     %ul.credits
       %li
         %span{:style => 'display:inline-block'}= t('wheelmap.footer.main_supporter')
-        = link_to "//community.wheelmap.org/about/partner/immobilienscout24/", id: 'immobilienscout24' do
+        = link_to "//news.wheelmap.org/about/partner/immobilienscout24/", id: 'immobilienscout24' do
           = image_tag('immoscout@2x.png', :size => '42x20', :alt => 'ImmobilienScout24', :title => 'ImmobilienScout24', :style => "margin-top: -3px;height:20px")
-        = link_to "//community.wheelmap.org/about/partner/allianz/", style: "display:none", id: 'allianz' do
+        = link_to "//news.wheelmap.org/about/partner/allianz/", style: "display:none", id: 'allianz' do
           = image_tag('allianz@2x.png', :size => '45x20', :alt => 'Allianz Logo', :title => 'Allianz', :style => "margin-top: -3px;height:20px")
       %li
         = link_to t('header.navigation.imprint'), community_imprint_url, :target => '_blank'

--- a/app/views/relaunch/_footer.html.haml
+++ b/app/views/relaunch/_footer.html.haml
@@ -18,9 +18,9 @@
     %ul.credits
       %li
         %span{:style => 'display:inline-block'}= t('wheelmap.footer.main_supporter')
-        = link_to "//news.wheelmap.org/about/partner/immobilienscout24/", id: 'immobilienscout24' do
+        = link_to "http://foerderung.sozialhelden.de/forderhelden/", id: 'immobilienscout24' do
           = image_tag('immoscout@2x.png', :size => '42x20', :alt => 'ImmobilienScout24', :title => 'ImmobilienScout24', :style => "margin-top: -3px;height:20px")
-        = link_to "//news.wheelmap.org/about/partner/allianz/", style: "display:none", id: 'allianz' do
+        = link_to "http://foerderung.sozialhelden.de/forderhelden/", style: "display:none", id: 'allianz' do
           = image_tag('allianz@2x.png', :size => '45x20', :alt => 'Allianz Logo', :title => 'Allianz', :style => "margin-top: -3px;height:20px")
       %li
         = link_to t('header.navigation.imprint'), community_imprint_url, :target => '_blank'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,7 +15,7 @@
     = image_tag('immoscout@2x.png', :size => '42x20', :alt => 'ImmobilienScout24', :title => 'ImmobilienScout24', :style => "margin-top: -3px;height:20px")
     %span>
       |
-    = link_to t('header.navigation.imprint'), "//community.wheelmap.org/kontakt", :target => '_blank'
+    = link_to t('header.navigation.imprint'), "//news.wheelmap.org/kontakt", :target => '_blank'
     %span>
       |
       = t('wheelmap.footer.a_project_of')

--- a/app/views/shared/_splash.html.haml
+++ b/app/views/shared/_splash.html.haml
@@ -16,4 +16,4 @@
   %p
     = link_to t('splash.start'), '#', :class => 'unblock-splash button splash-start'
   %p
-    = link_to t('splash.what_is_wheelmap'), '//community.wheelmap.org/', :class => 'whatis'
+    = link_to t('splash.what_is_wheelmap'), '//news.wheelmap.org/', :class => 'whatis'

--- a/app/views/terms/index.html.haml
+++ b/app/views/terms/index.html.haml
@@ -2,7 +2,7 @@
   .content
     = semantic_form_for current_user, :url => terms_profile_path do |form|
 
-      - terms_blog_url = I18n.locale == :de ? '//news.wheelmap.org/impressum/nutzungsbedingungen/' : '//news.wheelmap.org/en/imprint/terms-of-use/'
+      - terms_blog_url = I18n.locale == :de ? '//news.wheelmap.org/nutzungsbedingungen/' : '//news.wheelmap.org/en/terms-of-use/'
       %iframe{:align => 'center', :src => terms_blog_url, :width => '100%', :height => '300', :frameborder => '0', :seamless => 'seamless'}
 
       .row-fluid
@@ -10,7 +10,7 @@
           = form.input :terms
 
       .mt30
-        - privacy_blog_url = I18n.locale == :de ? '//news.wheelmap.org/impressum/datenschutzerklarung/' : '//news.wheelmap.org/en/imprint/privacy/'
+        - privacy_blog_url = I18n.locale == :de ? '//news.wheelmap.org/datenschutz/' : '//news.wheelmap.org/en/privacy/'
         %iframe{:align => 'center', :src => privacy_blog_url, :width => '100%', :height => '300', :frameborder => '0', :seamless => 'seamless'}
 
       .row-fluid
@@ -18,4 +18,3 @@
           = form.input :privacy_policy
       = form.actions do
         = form.action :submit, :label => t('formtastic.labels.save')
-

--- a/app/views/terms/index.html.haml
+++ b/app/views/terms/index.html.haml
@@ -2,7 +2,7 @@
   .content
     = semantic_form_for current_user, :url => terms_profile_path do |form|
 
-      - terms_blog_url = I18n.locale == :de ? '//community.wheelmap.org/impressum/nutzungsbedingungen/' : '//community.wheelmap.org/en/imprint/terms-of-use/'
+      - terms_blog_url = I18n.locale == :de ? '//news.wheelmap.org/impressum/nutzungsbedingungen/' : '//news.wheelmap.org/en/imprint/terms-of-use/'
       %iframe{:align => 'center', :src => terms_blog_url, :width => '100%', :height => '300', :frameborder => '0', :seamless => 'seamless'}
 
       .row-fluid
@@ -10,7 +10,7 @@
           = form.input :terms
 
       .mt30
-        - privacy_blog_url = I18n.locale == :de ? '//community.wheelmap.org/impressum/datenschutzerklarung/' : '//community.wheelmap.org/en/imprint/privacy/'
+        - privacy_blog_url = I18n.locale == :de ? '//news.wheelmap.org/impressum/datenschutzerklarung/' : '//news.wheelmap.org/en/imprint/privacy/'
         %iframe{:align => 'center', :src => privacy_blog_url, :width => '100%', :height => '300', :frameborder => '0', :seamless => 'seamless'}
 
       .row-fluid
@@ -18,3 +18,4 @@
           = form.input :privacy_policy
       = form.actions do
         = form.action :submit, :label => t('formtastic.labels.save')
+


### PR DESCRIPTION
This PR changes several hard coded URLs  in the app in favor of the switch from `community.wheelmap.org` to `news.wheelmap.org` (according to the spreadsheet list).

Related issue: #367 
