### PR TITLE
Fix branch for staging deployments.

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -6,7 +6,7 @@ set :rails_env, "staging" #added for delayed job
 set :stage, :staging
 set :deploy_to, "/var/apps/#{fetch(:application)}/"
 
-set :branch, :"feature/infrastructure-rebuild"
+set :branch, :"feature/infra-rebuild"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 # Simple Role Syntax


### PR DESCRIPTION
We had staging pointed to an old branch. This fixes it.