### PR TITLE
Fix URL for news.wheelmap.org

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,9 +97,9 @@ module ApplicationHelper
 
   def community_blog_url
     if I18n.locale == :de
-      "//news.wheelmap.org/news/"
+      "//news.wheelmap.org/#news"
     else
-      "//news.wheelmap.org/en/news/"
+      "//news.wheelmap.org/en/#news"
     end
   end
 


### PR DESCRIPTION
This PR corrects the URL for the news blog.

The change was demanded by Svenja (2016, Sept 6) in issue #367.