### PR TITLE
Use asset manifest

### DIFF
--- a/app/assets/stylesheets/relaunch/_container.scss
+++ b/app/assets/stylesheets/relaunch/_container.scss
@@ -1,5 +1,5 @@
 #container {
-  background: url('container_bg.png') repeat-x 0 $headerHeight;
+  background: asset-url('container_bg.png') repeat-x 0 $headerHeight;
   display: block;
   padding-bottom: $footerHeight + 10px;
   padding-top: $headerHeight;
@@ -45,10 +45,10 @@
     padding-left: 80px;
   }
   p.osm {
-    background: url("/assets/openstreetmap_logo_small.jpg") no-repeat left center;
+    background: asset-url("/assets/openstreetmap_logo_small.jpg") no-repeat left center;
   }
   p.wheelmap {
-    background: url("/assets/markerhead.jpg") no-repeat 4px center;
+    background: asset-url("/assets/markerhead.jpg") no-repeat 4px center;
   }
 
   em {

--- a/app/assets/stylesheets/relaunch/_fonts.scss
+++ b/app/assets/stylesheets/relaunch/_fonts.scss
@@ -3,6 +3,6 @@ $helvetica_light: 'HelveticaNeue-Light','Helvetica Neue Light','Helvetica Neue',
 
 @font-face {
   font-family: 'EntypoRegular';
-  src: url('entypo.eot');
-  src: url('entypo.eot?#iefix') format("embedded-opentype"), url('entypo.woff') format("woff"), url('entypo.ttf') format("truetype"), url('entypo.svg#EntypoRegular') format("svg");
+  src: asset-url('entypo.eot');
+  src: asset-url('entypo.eot?#iefix') format("embedded-opentype"), asset-url('entypo.woff') format("woff"), asset-url('entypo.ttf') format("truetype"), asset-url('entypo.svg#EntypoRegular') format("svg");
 }

--- a/app/assets/stylesheets/relaunch/_footer.scss
+++ b/app/assets/stylesheets/relaunch/_footer.scss
@@ -64,7 +64,7 @@
     border-left: 0;
     padding: 1px 4px;
     margin-left: 5px;
-    background: url(/assets/bubble-left.png) no-repeat -5px center;
+    background: asset-url('/assets/bubble-left.png') no-repeat -5px center;
   }
 }
 

--- a/app/assets/stylesheets/relaunch/_header.scss
+++ b/app/assets/stylesheets/relaunch/_header.scss
@@ -8,10 +8,10 @@
   left: 0;
   z-index: 2;
   float: left;
-  background: url('bg_header.png');
+  background: asset-url('bg_header.png');
 
   @include if-min-resolution(1.3) {
-    background: url(bg_header@2x.png);
+    background: asset-url('bg_header@2x.png');
   }
 
   .navbar-inner {
@@ -31,10 +31,10 @@
     margin: 7px 0 0 0;
     float: left;
     position: relative;
-    background: url(bg_logo.png) center left no-repeat;
+    background: asset-url('bg_logo.png') center left no-repeat;
 
     @include if-min-resolution(1.3) {
-      background: url(bg_logo@2x.png) center left no-repeat;
+      background: asset-url('bg_logo@2x.png') center left no-repeat;
       background-size: 150px 32px;
     }
 
@@ -61,11 +61,11 @@
     .christmas & {
       width: 160px;
       height: 42px;
-      background-image: url(bg_logo_christmas.png);
+      background-image: asset-url('bg_logo_christmas.png');
       margin-top: 0;
 
       @include if-min-resolution(1.3) {
-        background-image: url(bg_logo_christmas@2x.png);
+        background-image: asset-url('bg_logo_christmas@2x.png');
         background-size: 150px 39px;
       }
 

--- a/app/assets/stylesheets/relaunch/_icons.scss
+++ b/app/assets/stylesheets/relaunch/_icons.scss
@@ -8,14 +8,14 @@
 }
 
 .leaflet-marker-icon {
-  background: transparent url('marker-sprites.png') no-repeat;
+  background: transparent asset-url('marker-sprites.png') no-repeat;
   width: 29px;
   height: 32px;
   margin-left: -15px;
   margin-top: -30px;
 
   @include if-min-resolution(1.3) {
-    background: transparent url('marker-sprites@2x.png') no-repeat;
+    background: transparent asset-url('marker-sprites@2x.png') no-repeat;
     background-size: 29px 128px;
   }
 

--- a/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
+++ b/app/assets/stylesheets/relaunch/_leaflet_overrides.scss
@@ -18,7 +18,7 @@
 
 .leaflet-control-locate {
   a {
-    background-image: url('locate_btn.png');
+    background-image: asset-url('locate_btn.png');
     background-position: center center;
     background-repeat: no-repeat;
     background-color: rgba(255,255,255,0.8);
@@ -28,18 +28,18 @@
     };
 
     @include if-min-resolution(1.3) {
-      background-image: url('locate_btn@2x.png');
+      background-image: asset-url('locate_btn@2x.png');
     }
   }
 
   &.requesting a {
-    background-image: url('spinner_locate.gif');
+    background-image: asset-url('spinner_locate.gif');
   }
 
   &.active a {
-    background-image: url(locate_btn_active.png);
+    background-image: asset-url('locate_btn_active.png');
     @include if-min-resolution(1.3) {
-      background-image: url('locate_btn_active@2x.png');
+      background-image: asset-url('locate_btn_active@2x.png');
     }
   }
 }

--- a/app/assets/stylesheets/relaunch/_map.scss
+++ b/app/assets/stylesheets/relaunch/_map.scss
@@ -36,7 +36,7 @@
   text-indent:-9999px;
   overflow:hidden;
   background-repeat:no-repeat;
-  background-image:url('mapbox_logo.png');
+  background-image: asset-url('mapbox_logo.png');
 
   @media screen and (max-width:$breakPhone) {
     bottom: 13px

--- a/app/assets/stylesheets/relaunch/_overlay.scss
+++ b/app/assets/stylesheets/relaunch/_overlay.scss
@@ -34,7 +34,7 @@
   top: 50%;
   margin: -325px 0 0 -350px;
   padding: 0 0 20px 0;
-  background: url('bg-overlay.png') #FFF no-repeat;
+  background: asset-url('bg-overlay.png') #FFF no-repeat;
   background-position: 0 219px;
   @include box-shadow(0 0 10px #333);
   @include border-radius(3px);
@@ -85,7 +85,7 @@
     margin: 0 0 40px 0;
     text-align: center;
 
-    background: url('logo-overlay.png') center top no-repeat;
+    background: asset-url('logo-overlay.png') center top no-repeat;
 
     font-size: 16px;
     line-height: 24px;

--- a/app/assets/stylesheets/relaunch/_toolbar.scss
+++ b/app/assets/stylesheets/relaunch/_toolbar.scss
@@ -133,7 +133,7 @@
       }
 
       &--yes {
-        background-image: url('toolbar_marker_yes.png');
+        background-image: asset-url('toolbar_marker_yes.png');
 
         .popover-title {
           background-color: $wheelchair-yes;
@@ -141,7 +141,7 @@
       }
 
       &--limited {
-        background-image: url('toolbar_marker_limited.png');
+        background-image: asset-url('toolbar_marker_limited.png');
 
         .popover-title {
           background-color: $wheelchair-limited;
@@ -149,7 +149,7 @@
       }
 
       &--no {
-        background-image: url('toolbar_marker_no.png');
+        background-image: asset-url('toolbar_marker_no.png');
 
         .popover-title {
           background-color: $wheelchair-limited;
@@ -157,7 +157,7 @@
       }
 
       &--unknown {
-        background-image: url('toolbar_marker_unknown.png');
+        background-image: asset-url('toolbar_marker_unknown.png');
 
         .popover-title {
           background-color: $wheelchair-unknown;
@@ -166,19 +166,19 @@
 
       @include if-min-resolution(1.3) {
         &--yes {
-          background-image: url(toolbar_marker_yes@2x.png);
+          background-image: asset-url('toolbar_marker_yes@2x.png');
         }
 
         &--limited {
-          background-image: url(toolbar_marker_limited@2x.png);
+          background-image: asset-url('toolbar_marker_limited@2x.png');
         }
 
         &--no {
-          background-image: url(toolbar_marker_no@2x.png);
+          background-image: asset-url('toolbar_marker_no@2x.png');
         }
 
         &--unknown {
-          background-image: url(toolbar_marker_unknown@2x.png);
+          background-image: asset-url('toolbar_marker_unknown@2x.png');
         }
       }
     }
@@ -193,7 +193,7 @@
     }
 
     &-icon {
-      background: url('toolbar_marker_icon.png') no-repeat;
+      background: asset-url('toolbar_marker_icon.png') no-repeat;
       background-size: 100%;
       width: image_width('toolbar_marker_icon.png');
       height: image_height('toolbar_marker_icon.png');
@@ -201,7 +201,7 @@
       margin-top: 1px; // Cosmetic surgery
 
       @include if-min-resolution(1.3) {
-        background-image: url('toolbar_marker_icon@2x.png');
+        background-image: asset-url('toolbar_marker_icon@2x.png');
       }
     }
 
@@ -616,4 +616,3 @@
     }
   }
 }
-

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,6 +44,9 @@ Rake::Task["deploy:compile_assets"].clear
 
 namespace :deploy do
 
+  desc 'Overwrite defailt :set_linked_dirs so it does not make a bad symlink'
+  task :set_linked_dirs => do true end
+
   desc 'Compile assets'
   task :compile_assets => [:set_rails_env] do
     # invoke 'deploy:assets:precompile'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,9 +44,11 @@ Rake::Task["deploy:compile_assets"].clear
 Rake::Task["deploy:set_linked_dirs"].clear
 
 namespace :deploy do
-  # We need to noop this because otherwise it creates an undesirable symlink 
-  # Ref: https://github.com/capistrano/rails/blob/54da36a2dda5084a3cbe380b4a8f1ba282379f72/lib/capistrano/tasks/assets.rake#L121
-  task :set_linked_dirs do end
+  
+  task :set_linked_dirs do
+     # noop due to cap/rails adding this to the run list
+     # Ref: https://github.com/capistrano/rails/blob/54da36a2dda5084a3cbe380b4a8f1ba282379f72/lib/capistrano/tasks/assets.rake#L121
+  end
 
   desc 'Compile assets'
   task :compile_assets => [:set_rails_env] do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,11 +41,12 @@ set :keep_releases, 5
 
 # Clear existing task so we can replace it rather than "add" to it.
 Rake::Task["deploy:compile_assets"].clear
+Rake::Task["deploy:set_linked_dirs"].clear
 
 namespace :deploy do
-
-  desc 'Overwrite defailt :set_linked_dirs so it does not make a bad symlink'
-  task :set_linked_dirs => do true end
+  # We need to noop this because otherwise it creates an undesirable symlink 
+  # Ref: https://github.com/capistrano/rails/blob/54da36a2dda5084a3cbe380b4a8f1ba282379f72/lib/capistrano/tasks/assets.rake#L121
+  task :set_linked_dirs do end
 
   desc 'Compile assets'
   task :compile_assets => [:set_rails_env] do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :bundle_binstubs, -> { shared_path.join('bin') }
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, %w{ log tmp vendor/bundle public/system public/assets node_modules }
+set :linked_dirs, %w{ log tmp vendor/bundle public/system node_modules }
 
 # Default value for keep_releases is 5
 set :keep_releases, 5

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,7 @@ set :rails_env, "production" #added for delayed job
 set :stage, :production
 set :deploy_to, "/var/apps/#{fetch(:application)}/"
 
-set :branch, :"feature/infrastructure-rebuild"
+set :branch, :"feature/infra-rebuild"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 # Simple Role Syntax

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -6,7 +6,7 @@ set :rails_env, "staging" #added for delayed job
 set :stage, :staging
 set :deploy_to, "/var/apps/#{fetch(:application)}/"
 
-set :branch, :"feature/infra-rebuild"
+set :branch, :"bugfix/apps-use-asset-manifest"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 # Simple Role Syntax

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -6,7 +6,7 @@ set :rails_env, "staging" #added for delayed job
 set :stage, :staging
 set :deploy_to, "/var/apps/#{fetch(:application)}/"
 
-set :branch, :"bugfix/apps-use-asset-manifest"
+set :branch, :"feature/infra-rebuild"
 set :rev, proc { `git rev-parse --short #{fetch(:branch)}`.chomp }
 
 # Simple Role Syntax


### PR DESCRIPTION
Uses the asset manifest throughout the `scss` files instead of using bare urls.

This enables the hashing present on the `infra-rebuild`.