### PR TITLE
Fix/500 server error in providers AND provided poi

### DIFF
--- a/app/admin/provided_poi.rb
+++ b/app/admin/provided_poi.rb
@@ -10,6 +10,11 @@ ActiveAdmin.register ProvidedPoi do
   filter :wheelchair, as: :select, collection: proc { Poi::WHEELCHAIR_STATUS_VALUES.map{|k,v| [ I18n.t("wheelchairstatus.#{k}"),k]}}
   filter :url
 
+  permit_params do
+    %i(provided_poi poi_id provider_id wheelchair url)
+  end
+
+
   action_item(:upload_csv, :only => :index) do
     link_to "Upload CSV", upload_csv_admin_provided_pois_path
   end
@@ -51,7 +56,7 @@ ActiveAdmin.register ProvidedPoi do
   form do |f|
     f.inputs do
       f.input :poi_id
-      f.input :provider, as: :select, collection: Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}.sort
+      f.input :provider, as: :select, collection: Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}
       f.input :wheelchair, as: :select, collection: Poi::WHEELCHAIR_STATUS_VALUES.map{|k,v| [I18n.t("wheelchairstatus.#{k}"),k]}
       f.input :url
     end

--- a/app/admin/provided_poi.rb
+++ b/app/admin/provided_poi.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register ProvidedPoi do
   belongs_to :poi, :optional => true
 
   filter :poi_id
-  filter :provider, as: :select, collection: proc { Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}.sort}
+  filter :provider, as: :select, collection: proc { Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}}
   filter :wheelchair, as: :select, collection: proc { Poi::WHEELCHAIR_STATUS_VALUES.map{|k,v| [ I18n.t("wheelchairstatus.#{k}"),k]}}
   filter :url
 

--- a/app/admin/provider.rb
+++ b/app/admin/provider.rb
@@ -3,6 +3,7 @@ ActiveAdmin.register Provider do
   menu :label => 'Anbieter', :parent => 'Premium'
 
   filter :name
+  filter :id
 
   action_item(:upload_csv, :only => :index) do
     link_to "Upload CSV", upload_csv_admin_provided_pois_path

--- a/app/admin/provider.rb
+++ b/app/admin/provider.rb
@@ -8,6 +8,10 @@ ActiveAdmin.register Provider do
     link_to "Upload CSV", upload_csv_admin_provided_pois_path
   end
 
+  permit_params do
+    %i(name logo)
+  end
+
   index do
     column :id
     column :name

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register User do
   filter :created_at
   filter :updated_at
   filter :accepted_at
-  filter :providers, :collection => Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}.sort
+  filter :providers, :collection => Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}
 
 
   controller do
@@ -74,7 +74,7 @@ ActiveAdmin.register User do
       f.input :osm_username, :label => 'OSM Username', :hint => false
     end
     f.inputs "Providers" do
-      f.input :providers, :collection => Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}.sort
+      f.input :providers, :collection => Provider.all.inject([]){|memo,r| memo << [r.name, r.id]; memo}
     end
     f.actions
   end


### PR DESCRIPTION
This PR fixes 2 error messages when trying to create a new `provider` & `provided poi` in the activeadmin dashboard:
-  `ActiveModel::ForbiddenAttributesError` (since Rails 4.x strong parameters are required)
- `Comparison of Array with Array failed` - it seems the sorting method doesn't work (anymore). To have the providers & provided poi work properly again for now, we removed the sorting function and will look into it later when the `providers` and `provided poi` pages need to be improved anyways.

Fixes issue:  #365 