### PR TITLE
Wheelchair tag not shown on wheelmap

### DIFF
--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -70,12 +70,14 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
   end
 
   def increment_user_counter!
+    return unless user.terms?
+
     if update_wheelchair?
-      user.increment!(:tag_counter) if user.terms?
+      user.increment!(:tag_counter)
     elsif update_toilet?
-      user.increment!(:toilet_counter) if user.terms?
+      user.increment!(:toilet_counter)
     else
-      user.increment!(:edit_counter) if user.terms?
+      user.increment!(:edit_counter)
     end
   end
 

--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -9,10 +9,10 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
     return unless Rails.env.production? || Rails.env.test?
 
     # Remove wheelchair tag if value is "unknown"
-    tags.delete("wheelchair") if tags[WHEELCHAIR_TAG_KEY] == 'unknown'
+    tags.delete(WHEELCHAIR_TAG_KEY) if tags[WHEELCHAIR_TAG_KEY] == 'unknown'
 
     # Remove wheelchair tag if value is "unknown"
-    tags.delete("toilets:wheelchair") if tags[WHEELCHAIR_TOILET_TAG_KEY] == 'unknown'
+    tags.delete(WHEELCHAIR_TOILET_TAG_KEY) if tags[WHEELCHAIR_TOILET_TAG_KEY] == 'unknown'
 
     client = Rosemary::OauthClient.new(user.access_token)
     new(element_id, type, tags, user, client, source, tags_to_delete).tap do |job|


### PR DESCRIPTION
PR for #334 

This fixes the problem that a user could not update both toilet and wheelchair status for a POI at the same time. With this change it is now possible to update both at the same time.
Also some small refactorings took place in the `UpdateTagsJob` class like extracting magic strings and moving big conditionals into methods.