### PR TITLE
Fix wrong HTML tag usage for breadcrumbs in the node add page.

### DIFF
--- a/app/assets/javascripts/NewNodeWidget/Breadcrumbs.js
+++ b/app/assets/javascripts/NewNodeWidget/Breadcrumbs.js
@@ -42,9 +42,9 @@ class Breadcrumbs extends Component {
 
       return (
         <li key={section} className={className}>
-          <button onClick={onClick}>
+          <a onClick={onClick}>
             <I18n scope={`nodes.new.form.section.${section}.name`} />
-          </button>
+          </a>
         </li>
       );
     });


### PR DESCRIPTION
Related to #407. 

Before:
<img width="484" alt="screenshot 2016-09-26 12 16 57" src="https://cloud.githubusercontent.com/assets/1609692/18830906/25bff9a4-83e3-11e6-8f8b-d04cff6782da.png">

After:
<img width="627" alt="screenshot 2016-09-26 12 13 10" src="https://cloud.githubusercontent.com/assets/1609692/18830905/25a21af6-83e3-11e6-8f95-387559074e51.png">