### PR TITLE
Fix/forbidden attributes error in active admin

### DIFF
--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -6,11 +6,13 @@ ActiveAdmin.register Category do
     %i(identifier)
   end
 
-  # For some reason, inherited resource update does not work.
-  def update
-    region = resource
-    region.update_attributes(params[:category])
-    super
+  controller do
+    # For some reason, inherited resource update does not work.
+    def update
+      region = resource
+      region.update_attributes(params[:category][:id])
+      super
+    end
   end
 
   index do

--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -1,16 +1,17 @@
 ActiveAdmin.register Category do
 
-  controller do
+  filter :identifier
 
-    # For some reason, inherited resource update does not work.
-    def update
-      region = resource
-      region.update_attributes(params[:category])
-      super
-    end
+  permit_params do
+    %i(identifier)
   end
 
-  filter :identifier
+  # For some reason, inherited resource update does not work.
+  def update
+    region = resource
+    region.update_attributes(params[:category])
+    super
+  end
 
   index do
     selectable_column
@@ -19,6 +20,4 @@ ActiveAdmin.register Category do
     column :name, :sortable => false
     actions
   end
-
-
 end

--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register Category do
     # For some reason, inherited resource update does not work.
     def update
       region = resource
-      region.update_attributes(params[:category][:id])
+      region.update_attributes(permitted_params[:category])
       super
     end
   end

--- a/app/admin/node_type.rb
+++ b/app/admin/node_type.rb
@@ -10,6 +10,10 @@ ActiveAdmin.register NodeType do
   filter :created_at
   filter :updated_at
 
+  permit_params do
+    %i(category identifier icon osm_key osm_value alt_osm_key alt_osm_value)
+  end
+
   index do
     selectable_column
     column :id
@@ -43,6 +47,4 @@ ActiveAdmin.register NodeType do
     end
     f.actions
   end
-
-
 end


### PR DESCRIPTION
This PR fixes following error:
 `ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError)` 

in:
- /admin/categories 
- /admin/node_types

Related issue: #404 