### PR TITLE
Measurements api mock

### DIFF
--- a/app/controllers/api/measurements_controller.rb
+++ b/app/controllers/api/measurements_controller.rb
@@ -1,0 +1,14 @@
+class Api::MeasurementsController < Api::ApiController
+  def create
+
+    if params.fetch(:photo, nil) == nil
+      return respond_to do |format|
+        format.json { render :json => { :error => 'photo is missing' }.to_json, :status => 400 }
+      end
+    end
+
+    respond_to do |format|
+      format.json { render :json => {:id => 1234 }.to_json, :status => 201 }
+    end
+  end
+end

--- a/app/controllers/api/measurements_controller.rb
+++ b/app/controllers/api/measurements_controller.rb
@@ -1,6 +1,7 @@
 class Api::MeasurementsController < Api::ApiController
-  def create
+  rescue_from ActiveRecord::RecordNotFound, :with => :render_404
 
+  def create
     if params.fetch(:photo, nil) == nil
       return respond_to do |format|
         format.json { render :json => { :error => 'photo is missing' }.to_json, :status => 400 }
@@ -10,5 +11,15 @@ class Api::MeasurementsController < Api::ApiController
     respond_to do |format|
       format.json { render :json => {:id => 1234 }.to_json, :status => 201 }
     end
+  end
+
+  def add_metadata
+    Poi.find(params[:node_id])
+  end
+
+  private
+
+  def render_404
+    render_exception(StandardError.new("Not found"), 404)
   end
 end

--- a/app/controllers/api/measurements_controller.rb
+++ b/app/controllers/api/measurements_controller.rb
@@ -15,6 +15,10 @@ class Api::MeasurementsController < Api::ApiController
 
   def add_metadata
     Poi.find(params[:node_id])
+
+    respond_to do |format|
+      format.json { render :json => {:id => 1234 }.to_json, :status => 201 }
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,8 @@ Wheelmap::Application.routes.draw do
         put :update_wheelchair
         put :update_toilet
       end
+      resources :measurements, only: [:create] do
+      end
       resources :photos do
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Wheelmap::Application.routes.draw do
         put :update_toilet
       end
       resources :measurements, only: [:create] do
+        post 'metadata' => 'measurements#add_metadata'
       end
       resources :photos do
       end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 describe Api::MeasurementsController do
-  let(:poi) { FactoryGirl.create(:poi) }
+  let(:poi) { Poi.first }
   let(:user) { FactoryGirl.create(:user) }
+
+  before do
+    FactoryGirl.create(:poi)
+  end
 
   describe 'create action' do
     def json_response
@@ -58,19 +62,26 @@ describe Api::MeasurementsController do
 
   describe 'add metadata for image' do
     let(:measurement_id) { 1234 }
-    let :door_metadata do
+    let :valid_door_metadata do
       {
         type: 'door',
         'description': 'Some user description',
         'data': {
           'width': 1.04
         }
-      }
+      }.to_json
     end
 
     it 'returns 404 if the node is not available' do
-      post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => door_metadata)
+      post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
       expect(response.status).to eq 404
+    end
+
+    describe 'add door metadata' do
+      it 'accepts valid json' do
+        post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
+        expect(response.status).to eq 201
+      end
     end
   end
 end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe Api::MeasurementsController do
-  describe 'create action' do
-    let(:poi) { FactoryGirl.create(:poi) }
-    let(:user) { FactoryGirl.create(:user) }
+  let(:poi) { FactoryGirl.create(:poi) }
+  let(:user) { FactoryGirl.create(:user) }
 
+  describe 'create action' do
     def json_response
       JSON.parse(response.body)
     end
@@ -13,44 +13,64 @@ describe Api::MeasurementsController do
       User.delete_all
     end
 
-    context 'with valid params' do
-      before do
-        post(:create, :node_id => poi.id, :api_key => user.authentication_token, :photo => fixture_file_upload('/placeholder.jpg'))
-      end
-
-      describe 'the response' do
-        it 'has status 201 Created' do
-          expect(response.status).to eql 201
+    describe 'image upload' do
+      context 'with valid params' do
+        before do
+          post(:create, :node_id => poi.id, :api_key => user.authentication_token, :photo => fixture_file_upload('/placeholder.jpg'))
         end
 
-        it 'returns id' do
-          expect(json_response['id']).to eq 1234
+        describe 'the response' do
+          it 'has status 201 Created' do
+            expect(response.status).to eql 201
+          end
+
+          it 'returns id' do
+            expect(json_response['id']).to eq 1234
+          end
+        end
+      end
+
+      context 'with missing image' do
+        before do
+          post(:create, :node_id => poi.id, :api_key => user.authentication_token)
+        end
+
+        it 'returns 400 Bad Request' do
+          expect(response.status).to eq 400
+        end
+
+        specify 'the error message indicates that the image is missing' do
+          expect(json_response['error']).to eq 'photo is missing'
+        end
+      end
+
+      context 'with missing api key' do
+        before do
+          post(:create, :node_id => poi.id, :photo => fixture_file_upload('/placeholder.jpg'))
+        end
+
+        it 'returns 401 Unauthorized' do
+          expect(response.status).to eq 401
         end
       end
     end
+  end
 
-    context 'with missing image' do
-      before do
-        post(:create, :node_id => poi.id, :api_key => user.authentication_token)
-      end
-
-      it 'returns 400 Bad Request' do
-        expect(response.status).to eq 400
-      end
-
-      specify 'the error message indicates that the image is missing' do
-        expect(json_response['error']).to eq 'photo is missing'
-      end
+  describe 'add metadata for image' do
+    let(:measurement_id) { 1234 }
+    let :door_metadata do
+      {
+        type: 'door',
+        'description': 'Some user description',
+        'data': {
+          'width': 1.04
+        }
+      }
     end
 
-    context 'with missing api key' do
-      before do
-        post(:create, :node_id => poi.id, :photo => fixture_file_upload('/placeholder.jpg'))
-      end
-
-      it 'returns 401 Unauthorized' do
-        expect(response.status).to eq 401
-      end
+    it 'returns 404 if the node is not available' do
+      post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => door_metadata)
+      expect(response.status).to eq 404
     end
   end
 end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Api::MeasurementsController do
+  describe 'create action' do
+    let(:poi) { FactoryGirl.create(:poi) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    def json_response
+      JSON.parse(response.body)
+    end
+
+    before :all do
+      User.delete_all
+    end
+
+    context 'with valid params' do
+      before do
+        post(:create, :node_id => poi.id, :api_key => user.authentication_token, :photo => fixture_file_upload('/placeholder.jpg'))
+      end
+
+      describe 'the response' do
+        it 'has status 201 Created' do
+          expect(response.status).to eql 201
+        end
+
+        it 'returns id' do
+          expect(json_response['id']).to eq 1234
+        end
+      end
+    end
+
+    context 'with missing image' do
+      before do
+        post(:create, :node_id => poi.id, :api_key => user.authentication_token)
+      end
+
+      it 'returns 400 Bad Request' do
+        expect(response.status).to eq 400
+      end
+
+      specify 'the error message indicates that the image is missing' do
+        expect(json_response['error']).to eq 'photo is missing'
+      end
+    end
+
+    context 'with missing api key' do
+      before do
+        post(:create, :node_id => poi.id, :photo => fixture_file_upload('/placeholder.jpg'))
+      end
+
+      it 'returns 401 Unauthorized' do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -72,6 +72,16 @@ describe Api::MeasurementsController do
       }.to_json
     end
 
+    let :valid_steps_metadata do
+      {
+        type: 'steps',
+        'description': 'Some user description',
+        'data': {
+          'height': 0.11
+        }
+      }.to_json
+    end
+
     it 'returns 404 if the node is not available' do
       post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
       expect(response.status).to eq 404
@@ -80,6 +90,13 @@ describe Api::MeasurementsController do
     describe 'add door metadata' do
       it 'accepts valid json' do
         post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
+        expect(response.status).to eq 201
+      end
+    end
+
+    describe 'add steps metadata' do
+      it 'accepts valid json' do
+        post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_steps_metadata)
         expect(response.status).to eq 201
       end
     end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -92,6 +92,16 @@ describe Api::MeasurementsController do
       }.to_json
     end
 
+    let :valid_toilet_metadata do
+      {
+        type: 'toilet',
+        'description': 'Some user description',
+        'data': {
+          'area': 15.42
+        }
+      }.to_json
+    end
+
     it 'returns 404 if the node is not available' do
       post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
       expect(response.status).to eq 404
@@ -114,6 +124,13 @@ describe Api::MeasurementsController do
     describe 'add ramp metadata' do
       it 'accepts valid json' do
         post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_ramp_metadata)
+        expect(response.status).to eq 201
+      end
+    end
+
+    describe 'add toilet metadata' do
+      it 'accepts valid json' do
+        post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_toilet_metadata)
         expect(response.status).to eq 201
       end
     end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -82,6 +82,16 @@ describe Api::MeasurementsController do
       }.to_json
     end
 
+    let :valid_ramp_metadata do
+      {
+        type: 'ramp',
+        'description': 'Some user description',
+        'data': {
+          'angle': 15.42
+        }
+      }.to_json
+    end
+
     it 'returns 404 if the node is not available' do
       post(:add_metadata, :node_id => 404, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_door_metadata)
       expect(response.status).to eq 404
@@ -97,6 +107,13 @@ describe Api::MeasurementsController do
     describe 'add steps metadata' do
       it 'accepts valid json' do
         post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_steps_metadata)
+        expect(response.status).to eq 201
+      end
+    end
+
+    describe 'add ramp metadata' do
+      it 'accepts valid json' do
+        post(:add_metadata, :node_id => poi.id, :measurement_id => measurement_id, :api_key => user.authentication_token, :metadata => valid_ramp_metadata)
         expect(response.status).to eq 201
       end
     end

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -47,7 +47,7 @@ describe NodesController do
     end
 
     it "should render not found page" do
-      get(:show, :id => 123)
+      get(:show, :id => 54385)
       expect(response).not_to be_success
       expect(response.code).to eql('404')
     end


### PR DESCRIPTION
PR related to #413 

This provides a very basic mock of the new measurement APIs. It accepts data but does not persist them yet. Also validation is not in place yet. 

The following two new endpoints are available:

```
POST /api/nodes/:node_id/measurements
```

Example:

```
$ curl -v -XPOST http://localhost:3000/api/nodes/268916145/measurements\?api_key=<API KEY> -F "photo=@placeholder.jpg" -H "Content-Type: multipart/form-data"
```

and:

```
POST /api/nodes/:node_id/measurements/:measurement_id/metadata
```

Example:

```
curl -v -XPOST http://localhost:3000/api/nodes/268916145/measurements/1234/metadata\?api_key=<API KEY> -d "{\"type\": \"door\",\"description\": \"some user description\",\"data\": {\"width\": 1.04}}"
```
