### PR TITLE
Don't disable API token box.

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -20,7 +20,7 @@
       - if @user.authentication_token
         = semantic_form_for :user, :url => reset_token_profile_path, html: { class: 'form-horizontal'},  :method => :post do |form|
           = form.inputs :name => 'API' do
-            = form.input :authentication_token, :input_html => {:readonly => :readonly, :disabled => :disabled}
+            = form.input :authentication_token, :input_html => {:readonly => :readonly}
 
           = form.actions do
             = form.action :submit, :label => t('formtastic.labels.reset')


### PR DESCRIPTION
Closes #419.

This has been tested in Firefox and Chrome and fixes the issue.

@schultyy r+?