### PR TITLE
Teach authentication tokens to properly reset.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -111,7 +111,9 @@ class UsersController < ApplicationController
   end
 
   def reset_token
-    current_user.reset_authentication_token! if current_user.authentication_token
+    # Clearing this triggers `ensure_authentication_token` which
+    # generates a new token.
+    current_user.update_attribute(:authentication_token, nil)
     redirect_to edit_profile_path
     return
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -33,6 +33,13 @@ describe UsersController do
     expect(response.code).to eq('400')
   end
 
+  it "should reset a users authentication token when requested" do
+    sign_in @user
+    old_token = @user.authentication_token
+    post :reset_token
+    expect(@user.reload.authentication_token).not_to eq(old_token)
+  end
+
   context "widget" do
     let(:user){
       FactoryGirl.create(:user, :email => 'widget@wheelmap.org',


### PR DESCRIPTION
Accomplishes this by updating the attribute to nil and allowing the
model to ensure the presence of a (new) token.

Fixes #422.

@schultyy / @1000miles  r+?