### PR TITLE
Store measurement photos

### DIFF
--- a/app/controllers/api/measurements_controller.rb
+++ b/app/controllers/api/measurements_controller.rb
@@ -8,6 +8,12 @@ class Api::MeasurementsController < Api::ApiController
       end
     end
 
+    poi = Poi.find(params[:node_id])
+    photo = poi.photos.build(image: params[:photo])
+    photo.user = current_user
+
+    poi.save
+
     respond_to do |format|
       format.json { render :json => {:id => 1234 }.to_json, :status => 201 }
     end

--- a/app/controllers/api/measurements_controller.rb
+++ b/app/controllers/api/measurements_controller.rb
@@ -15,7 +15,7 @@ class Api::MeasurementsController < Api::ApiController
     poi.save
 
     respond_to do |format|
-      format.json { render :json => {:id => 1234 }.to_json, :status => 201 }
+      format.json { render :json => {:id => photo.id }.to_json, :status => 201 }
     end
   end
 

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -89,6 +89,20 @@ describe Api::MeasurementsController do
           expect(response.status).to eq 401
         end
       end
+
+      context 'with non existant node' do
+        before do
+          post(:create, :node_id => 999999, :api_key => user.authentication_token, :photo => fixture_file_upload('/placeholder.jpg'))
+        end
+
+        it 'returns 404' do
+          expect(response.status).to eq 404
+        end
+
+        it 'does not save a new measurement' do
+          expect(poi.photos.count).to eq 0
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -23,6 +23,15 @@ describe Api::MeasurementsController do
           post(:create, :node_id => poi.id, :api_key => user.authentication_token, :photo => fixture_file_upload('/placeholder.jpg'))
         end
 
+        it 'creates a photo associated with the poi' do
+          expect(poi.photos.count).to eq 1
+        end
+
+        it "creates a photo with the current user assigned" do
+          photo = poi.photos.first
+          expect(photo.user).to eq user
+        end
+
         describe 'the response' do
           it 'has status 201 Created' do
             expect(response.status).to eql 201

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -56,11 +56,33 @@ describe Api::MeasurementsController do
         specify 'the error message indicates that the image is missing' do
           expect(json_response['error']).to eq 'photo is missing'
         end
+
+        it 'does not save a new photo for the poi' do
+          expect(poi.photos.count).to eq 0
+        end
       end
 
       context 'with missing api key' do
         before do
           post(:create, :node_id => poi.id, :photo => fixture_file_upload('/placeholder.jpg'))
+        end
+
+        it 'returns 401 Unauthorized' do
+          expect(response.status).to eq 401
+        end
+
+        it 'does not save a new photo for the poi' do
+          expect(poi.photos.count).to eq 0
+        end
+      end
+
+      context 'with invalid api key' do
+        before do
+          post(:create, :node_id => poi.id, api_key: '12354645543534534', :photo => fixture_file_upload('/placeholder.jpg'))
+        end
+
+        it 'does not save a new photo for the poi' do
+          expect(poi.photos.count).to eq 0
         end
 
         it 'returns 401 Unauthorized' do

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -38,7 +38,8 @@ describe Api::MeasurementsController do
           end
 
           it 'returns id' do
-            expect(json_response['id']).to eq 1234
+            photo = poi.photos.first
+            expect(json_response['id']).to eq photo.id
           end
         end
       end


### PR DESCRIPTION
PR for #413 

This PR adds the actual implementation behind:
```
POST /api/nodes/:node_id/measurements
```

These measurement images are stored as regular images. With this change we also ensure that they're going to be displayed together with the other regular images as well. 