### PR TITLE
Fix uploads on new infra

### DIFF
--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -20,7 +20,9 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     File.join('system', 'uploads', model.class.to_s.underscore, subdirs)
-    # File.join('uploads', model.class.to_s.underscore, mounted_as.to_s, subdirs)
+  end
+  def cache_dir
+    File.join('system', 'uploads', 'tmp', model.class.to_s.underscore)
   end
 
   def subdirs

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -73,6 +73,11 @@ namespace :deploy do
         remote_dir = "#{host.user}@#{host.hostname}:#{release_path}/public/"
         execute "mkdir -p #{release_path}/public/assets/"
         run_locally { execute "rsync -av --delete #{local_dir} #{remote_dir}" }
+
+        # We need to link the existing shared `/var/apps/wheelmap/public/system` folder
+        # into the new release.
+        execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/system"
+
         # We create this file so the consul health check will pass. We can't use an
         # existing file since they are all unpredictably named.
         execute "touch #{release_path}/public/assets/ping"
@@ -106,7 +111,7 @@ namespace :deploy do
     end
   end
 
-  desc 'Stopp application'
+  desc 'Stop application'
   task :stop do
     on roles(:app), in: :sequence, wait: 5 do
       sudo "systemctl stop webapp.service"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,7 +76,7 @@ namespace :deploy do
 
         # We need to link the existing shared `/var/apps/wheelmap/public/system` folder
         # into the new release.
-        execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/system"
+        execute :ln, "-s", "#{deploy_path}/public/system/uploads", "#{release_path}/public/system"
 
         # We create this file so the consul health check will pass. We can't use an
         # existing file since they are all unpredictably named.


### PR DESCRIPTION
Due to permissions and the NFS mounts on the new infra we need a bit of a different way of handling uploads.

Tested on new production.

![screen shot 2016-10-19 at 16 08 44](https://cloud.githubusercontent.com/assets/130903/19522108/5737b9b4-9616-11e6-9322-cc4e97ffb450.png)
