### PR TITLE
Find resource by slug instead of name

### DIFF
--- a/app/admin/region.rb
+++ b/app/admin/region.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register Region do
 
   controller do
     def find_resource
-      Region.find_by(name: params[:id])
+      Region.find_by(slug: params[:id])
     end
 
     def update


### PR DESCRIPTION
This PR fixes the `500 Internal Server Error` in `/admin/regions` after some wkt-files have been renamed due to umlauts issue (https://github.com/sozialhelden/wheelmap/issues/82). 

Finding a resource by `slug` is recommended rather than finding by `name` because names are supposed to change more often.

Example:
```
+-----+------------------+------------------+
| id  | name             | slug             |
+-----+------------------+------------------+
| 000 | Kreis Böblingen | kreis-boeblingen | 
+-----+------------------+------------------+
1 row in set (0.00 sec)
```