### PR TITLE
Only log WARN and ERROR on production.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Wheelmap::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  config.log_level = :info
+  config.log_level = :warn
 
   config.logger = Logger.new($stdout)
 


### PR DESCRIPTION
This will help reduce log volumes.
