### PR TITLE
Write csv files in batches

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -229,7 +229,7 @@ namespace :export do
       csv << ["Id","Name","Lat","Lon","Street","Housenumber","Postcode","City","Wheelchair","Type","Category"]
       regions.each do |region|
         categories.each do |category|
-          Poi.unknown_accessibility.where(region_id: region).where(node_type_id: category.node_types.where.not(identifier: 'memorial')).includes(:photos).where(photos: {poi_id: nil }).order('version DESC').each do |poi|
+          Poi.unknown_accessibility.where(region_id: region).where(node_type_id: category.node_types.where.not(identifier: 'memorial')).includes(:photos).where(photos: {poi_id: nil }).order('version DESC').find_each do |poi|
             csv <<
               [
                 poi.id,


### PR DESCRIPTION
This PR changes the method from `each` to [`find_each`](http://guides.rubyonrails.org/active_record_querying.html) to receive results in batches in the rake task `:for_streetspotr_no_photo_no_memorial`. 

