### PR TITLE
Fix querying for Pois without images

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -225,11 +225,11 @@ namespace :export do
     node_types = category_names.map do |category_name|
       category = Category.find_by(identifier: category_name)
       category.node_types.where.not(identifier: 'memorial')
-    end.flatten.uniq
+    end.flatten.uniq.map(&:id).sort
 
     CSV.open("streetspotr_#{region_names.take(3).join('_')}.csv", "wb", :force_quotes => true) do |csv|
       csv << ["Id","Name","Lat","Lon","Street","Housenumber","Postcode","City","Wheelchair","Type","Category"]
-      Poi.unknown_accessibility.where(region_id: regions).where(node_type_id: node_types ).includes(:photos).where(photos: {poi_id: nil }).order('version DESC').find_each do |poi|
+      Poi.unknown_accessibility.where(region_id: regions).where(node_type_id: node_types).where("(select count(*) from photos where photos.poi_id=pois.osm_id) = 0").order('version DESC').each do |poi|
         csv <<
           [
             poi.id,


### PR DESCRIPTION
This improves the total time the query runs. For Berlin, Hamburg, Munich it took over 20 mins before, now it takes around 5.
We updated the mechanism for querying for Pois which do not have any photos associated. Also we sort node type ids before we pass them in. 