### PR TITLE
Replace spaces with underscore in region names for csv export

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -227,7 +227,7 @@ namespace :export do
       category.node_types.where.not(identifier: 'memorial')
     end.flatten.uniq.map(&:id).sort
 
-    CSV.open("streetspotr_#{region_names.take(3).join('_')}.csv", "wb", :force_quotes => true) do |csv|
+    CSV.open("streetspotr_#{region_names.take(3).join('_').gsub(/\s+/,"_")}.csv", "wb", :force_quotes => true) do |csv|
       csv << ["Id","Name","Lat","Lon","Street","Housenumber","Postcode","City","Wheelchair","Type","Category"]
       Poi.unknown_accessibility.where(region_id: regions).where(node_type_id: node_types).where("(select count(*) from photos where photos.poi_id=pois.osm_id) = 0").order('version DESC').each do |poi|
         csv <<


### PR DESCRIPTION
When region names contain one or more spaces between a region name, e.g. `Sankt Petersburg` or `Sankt Petersburg Placeholder`, then the csv filename was previously cut, e.g. `streetspotr_Moskau_Sankt.csv`. This PR replaces these spaces with an underscore (`"_"`) each.

Examples:
"Moskau,Sankt Petersburg,Nowosibirsk"
"Moskau,Sankt Petersburg Placeholder,Nowosibirsk"

CSV filename will be saved as:
`streetspotr_Moskau_Sankt_Petersburg_Nowosibirsk.csv`
`streetspotr_Moskau_Sankt_Petersburg_Placeholder_Nowosibirsk.csv`