### PR TITLE
Fix broken poi:locate rake task

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -15,7 +15,7 @@ class Region < ActiveRecord::Base
   GEO_FACTORY = RGeo::Cartesian.factory
   set_rgeo_factory_for_column(:grenze, GEO_FACTORY)
 
-  scope :parent_id, lambda {|parent_id| { :conditions => { :parent_id => parent_id }}}
+  scope :parent_id, lambda {|parent_id| where(parent_id: parent_id) }
   scope :depth, lambda { |depth| where(:depth => depth) }
 
   def pois_of_children

--- a/lib/poi_locator.rb
+++ b/lib/poi_locator.rb
@@ -24,7 +24,7 @@ class PoiLocator
     end
 
     lowest_id = Poi.lowest_id
-    Poi.find_in_batches(:conditions => {:region_id => @parent_id }, :start => lowest_id) do |batch|
+    Poi.where(region_id: @parent_id).find_in_batches(:start => lowest_id) do |batch|
       poi_regions = {}
       Poi.transaction do
         batch.each do |poi|


### PR DESCRIPTION
This task was not working because it used deprecated ActiveRecord query methods which have been removed after Rails 4.0.

This resolves #444.