### PR TITLE
Rename rake task after 'no photo' param query removal

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -209,8 +209,8 @@ namespace :export do
     end
   end
 
-  desc 'Export CSV nodes for streetspotr in region and category without photos and node_type memorial'
-  task :for_streetspotr_no_photo_no_memorial => :environment do
+  desc 'Export CSV nodes for streetspotr in region and category without node_type memorial'
+  task :for_streetspotr_no_memorial => :environment do
     region_names    = ENV['REGION'].split(',')      rescue nil
     category_names  = ['food', 'shopping', 'accommodation', 'tourism']
     raise "Usage: rake export:for_streetspotr REGION=Berlin,Leipzig" unless region_names


### PR DESCRIPTION
Since we don't query `has no photo` for the csv exports anymore, we also need to rename and modify the description of the rake task.

This PR changes the rake task name from `for_streetspotr_no_photo_no_memorial` to `for_streetspotr_no_memorial` 

=> `bundle exec rake export:for_streetspotr_no_memorial`
