### PR TITLE
Switch from git to https protocol for carrierwave source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :default do
   gem 'activeadmin', '~> 1.0.0.pre2'
   gem 'kaminari', '~> 0.14'
   gem 'kaminari-i18n'
-  gem 'carrierwave', github: 'carrierwaveuploader/carrierwave', ref: 'c2ee2e8' # to be used before release 0.11.0 becaus of deprecation warnings
+  gem 'carrierwave', :git => 'https://github.com/carrierwaveuploader/carrierwave', ref: 'c2ee2e8' # to be used before release 0.11.0 becaus of deprecation warnings
   gem 'carrierwave-meta', '~> 0.0.7'
   gem 'carrierwave_backgrounder', '~> 0.4.2'
   gem 'rmagick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/carrierwaveuploader/carrierwave.git
+  remote: https://github.com/carrierwaveuploader/carrierwave
   revision: c2ee2e89d3aa447c6b81186be6d627202d33a97f
   ref: c2ee2e8
   specs:
@@ -648,4 +648,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
This PR switches the source from `git` to `https protocol` for carrierwave.

Related warning while `bundle install` process:
```
The git source `git://github.com/carrierwaveuploader/carrierwave.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```