### PR TITLE
Instruct to install mysql-server-5.6 due to geometry issues with v5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Repository is the source code of the website [Wheelmap.org](http://wheelmap
 
 - Ruby 2.2.2
 - Bundler
-- MySQL
+- MySQL 5.6 (< 5.7)
 - ImageMagick
 - PhantomJS
 - Node >= 4.1
@@ -85,8 +85,10 @@ Ubuntu
 
 ```
 $ sudo apt-get update
-$ sudo apt-get install -y libmysqlclient-dev mysql-server
+$ sudo apt-get install -y libmysqlclient-dev mysql-server-5.6
+
 ```
+Note: Please make sure to install a mysql-server version that is before `v5.7` due to some geometry issues.
 
 #### Install ImageMagick:
 


### PR DESCRIPTION
This PR instructs to use mysql server v5.6 as long as v5.7 has issues with multipolygons/polygons.

Related issue: #471 

**Successfully tested with:**
- Ubuntu 16.04 (bento)
- Vagrant 1.8.4
- mysql-server-5.6
- libmysqlclient-dev

