### PR TITLE
Pin ActiveAdmin to version 1.0.0.pre2 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :default do
   gem 'librato-metrics'
   gem 'librato-rails'
   gem 'multipart-post'
-  gem 'activeadmin', '~> 1.0.0.pre2'
+  gem 'activeadmin', '1.0.0.pre2'
   gem 'kaminari', '~> 0.14'
   gem 'kaminari-i18n'
   gem 'carrierwave', :git => 'https://github.com/carrierwaveuploader/carrierwave', ref: 'c2ee2e8' # to be used before release 0.11.0 becaus of deprecation warnings

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,7 +540,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-page_caching (~> 1.0, >= 1.0.2)
-  activeadmin (~> 1.0.0.pre2)
+  activeadmin (= 1.0.0.pre2)
   activerecord-import (>= 0.4.0)
   activerecord-mysql2spatial-adapter (~> 0.5.0.nonrelease)
   activeresource


### PR DESCRIPTION
This PR pins activeadmin at 1.0.0.pre2 to prevent breaking changes for later versions.


We figured out that if we use a more recent version it breaks a lot of stuff right now. Until we've time to investigate we stick with pre2.