### PR TITLE
Fix/asset pipeline after rails 4 upgrade

### DIFF
--- a/app/admin/node_type.rb
+++ b/app/admin/node_type.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register NodeType do
     selectable_column
     column :id
     column :icon do |node_type|
-      image_tag("/assets/icons/#{node_type.icon}")
+      image_tag("icons/#{node_type.icon}")
     end
     column :name, :sortable => false
     column :category, :sortable => false

--- a/app/views/node_types/_node_type.html.haml
+++ b/app/views/node_types/_node_type.html.haml
@@ -1,5 +1,5 @@
 %tr
   %td=node_type.localized_name
-  %td=image_tag("/assets/icons/#{node_type.icon}", :size => '22x22')
+  %td=image_tag("icons/#{node_type.icon}", :size => '22x22')
   %td=link_to "#{node_type.osm_key}=#{node_type.osm_value}", "http://wiki.openstreetmap.org/wiki/Tag:#{node_type.osm_key}%3D#{node_type.osm_value}"
   %td=number_with_delimiter(node_type.pois.count)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -54,12 +54,10 @@ Wheelmap::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  #config.serve_static_assets = true
   config.serve_static_assets = false
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   config.action_controller.asset_host = 'staging.wheelmap.org'
-  #config.action_controller.asset_host = '192.168.33.24:3000'
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -54,10 +54,12 @@ Wheelmap::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
+  #config.serve_static_assets = true
   config.serve_static_assets = false
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   config.action_controller.asset_host = 'staging.wheelmap.org'
+  #config.action_controller.asset_host = '192.168.33.24:3000'
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -19,7 +19,7 @@ Wheelmap::Application.configure do
   config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Generate digests for assets URLs
   config.assets.digest = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -19,7 +19,7 @@ Wheelmap::Application.configure do
   config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Generate digests for assets URLs
   config.assets.digest = true


### PR DESCRIPTION
On following pages some icons were not displayed:
- http://staging.wheelmap.org/node_types
- http://staging.wheelmap.org/admin/node_types

By correcting the path and using the image_tag we benefit from the rails 4 asset pipeline, e.g. to create fingerprinted-assets under `public/assets`.

**wrong:**
`image_tag("assets/icons/#{node_type.icon}")` results in `public/assets/assets/icons/icon-1fdbe00e2d8aa5254dcf9d1f119745.png`

**corrected:**
`image_tag("icons/#{node_type.icon}")` results in `public/assets/icons/icon-1fdbe00e2d8aa5254dcf9d1f119745.png`

This PR fixes Github issue #476 