### PR TITLE
Feature/more keys for community support form

### DIFF
--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -17,6 +17,7 @@ class CommunitySupportController < ApplicationController
 
     if @support_request.valid?
       CommunitySupportMailer.send_to_support_team(@support_request).deliver
+      flash[:notice] = I18n.t('community_support_form.new.form.flash_after_submit')
       redirect_to root_path
     else
       render "new"

--- a/app/views/community_support/new.html.haml
+++ b/app/views/community_support/new.html.haml
@@ -4,5 +4,5 @@
       = semantic_form_for(@support_request, :url => community_support_index_path ) do |f|
         = f.input :name
         = f.input :email, hint: ""
-        = f.input :message, as: :text , label: "Please describe info here but only in German or English please"
+        = f.input :message, as: :text , label: I18n.t('community_support_form.new.form.describe')
         = f.action :submit

--- a/app/views/relaunch/_header.html.haml
+++ b/app/views/relaunch/_header.html.haml
@@ -46,4 +46,4 @@
               %li= link_to t('header.navigation.blog', :default => :en), community_blog_url
               %li= link_to t('header.navigation.press', :default => :en), community_press_url
               %li= link_to t('header.navigation.contact', :default => :en), community_contact_url
-              %li= link_to 'Report bug', new_community_support_url
+              %li= link_to t('header.navigation.report_problem', :default => :en), new_community_support_url


### PR DESCRIPTION
This PR is additional to PR #488 & PR #490 and does following:
- implements flash message after form submit
- converts previously hard coded strings to locale keys

Related Github issue:
#370 