### PR TITLE
Provide german translation for new community support form

### DIFF
--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -12,6 +12,11 @@ de:
         address_housenumber: Nummer
         address_postcode: Postleitzahl
         address_city: Stadt
+  community_support_form:
+    new:
+      form:
+        describe: Bitte schreibe uns in Englisch oder Deutsch.
+        flash_after_submit: Vielen Dank, dass du uns kontaktiert hast. Unser Support Team meldet sich so bald wie möglich bei dir zurück.
   faq:
     answers:
       0: Du kannst die Markierung jederzeit selbst ändern. Einfach die richtige Markierung wählen und "Speichern" - fertig!
@@ -29,6 +34,7 @@ de:
       contact: Kontakt
       map: Karte
       projects: Mitmachen
+      report_problem: Problem melden
     toolbar:
       categories: Kategorien
     meta:


### PR DESCRIPTION
Since wheelmap uses DE as default locale, it would display errors like translation is missing. To fix this we place german text in advance with this PR and will pull the german translations from Transifex in a later step.

Please see:
![00000211](https://cloud.githubusercontent.com/assets/4077916/20801981/d6718908-b7ea-11e6-8977-674b553a0a9b.png)

Related Github issue: #370 


