### PR TITLE
Enable translation key for submit button on community support form

### DIFF
--- a/app/views/community_support/new.html.haml
+++ b/app/views/community_support/new.html.haml
@@ -11,4 +11,4 @@
       = f.input :name
       = f.input :email, hint: ""
       = f.input :message, as: :text , label: I18n.t('community_support_form.new.form.describe')
-      = f.action :submit
+      = f.action :submit, as: :button, label: I18n.t('community_support_form.new.form.submit_button')

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -26,6 +26,7 @@ de:
         note: 'Bitte beachte: Die Wheelmap ist ein Projekt eines gemeinnützigen Vereins und wir haben nur begrenzte Ressourcen, um die App weiterzuentwickeln.'
         describe: Bitte schreibe uns in Englisch oder Deutsch.
         flash_after_submit: Vielen Dank, dass du uns kontaktiert hast. Unser Support Team meldet sich so bald wie möglich bei dir zurück.
+        submit_button: Abschicken
   faq:
     answers:
       0: Du kannst die Markierung jederzeit selbst ändern. Einfach die richtige Markierung wählen und "Speichern" - fertig!

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -25,6 +25,7 @@ en:
         note: Note that Wheelmap is an open-source project run by a non-profit organization and we have limited resources for the app development.
         describe: Please write to us in English or German.
         flash_after_submit: Thank you for contacting us. Our support team will get back to you as soon as possible.
+        submit_button: Submit
   faq:
     answers:
       0: You can always change the marking of a place yourself. Just choose the right marking and "Save" - done!


### PR DESCRIPTION
This PR prepares the submit button to be translated based on the locale switcher.

Related Github issue: #370 