### PR TITLE
Gather additional support form data

### DIFF
--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -45,15 +45,21 @@ class CommunitySupportController < ApplicationController
   end
 
   def status_filters
-    request.cookies['last_status_filters']
+    filters = request.cookies['last_status_filters']
+    return nil if filters.nil?
+    JSON.parse(filters)
   end
 
   def category_filters
-    request.cookies['last_category_filters']
+    filters = request.cookies['last_category_filters']
+    return nil if filters.nil?
+    JSON.parse(filters)
   end
 
   def toilet_filters
-    request.cookies['last_toilet_filters']
+    filters = request.cookies['last_toilet_filters']
+    return nil if filters.nil?
+    JSON.parse(filters)
   end
 
   def form_params

--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -12,7 +12,7 @@ class CommunitySupportController < ApplicationController
                                        latitude: latitude,
                                        longitude: longitude,
                                        last_zoom_level: zoom_level,
-                                       status_filters: status_filters,
+                                       wheelchair_status_filters: wheelchair_status_filters,
                                        category_filters: category_filters,
                                        toilet_filters: toilet_filters)
     @support_request = CommunitySupportRequest.new(support_params)
@@ -44,7 +44,7 @@ class CommunitySupportController < ApplicationController
     request.cookies['last_zoom']
   end
 
-  def status_filters
+  def wheelchair_status_filters
     filters = request.cookies['last_status_filters']
     return nil if filters.nil?
     JSON.parse(filters)

--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -11,7 +11,8 @@ class CommunitySupportController < ApplicationController
     support_params = form_params.merge(user_agent: request.user_agent,
                                        latitude: latitude,
                                        longitude: longitude,
-                                       last_zoom_level: zoom_level)
+                                       last_zoom_level: zoom_level,
+                                       status_filters: status_filters)
     @support_request = CommunitySupportRequest.new(support_params)
     if current_user
       @support_request.is_logged_in = true
@@ -39,6 +40,10 @@ class CommunitySupportController < ApplicationController
 
   def zoom_level
     request.cookies['last_zoom']
+  end
+
+  def status_filters
+    request.cookies['last_status_filters']
   end
 
   def form_params

--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -13,7 +13,8 @@ class CommunitySupportController < ApplicationController
                                        longitude: longitude,
                                        last_zoom_level: zoom_level,
                                        status_filters: status_filters,
-                                       category_filters: category_filters)
+                                       category_filters: category_filters,
+                                       toilet_filters: toilet_filters)
     @support_request = CommunitySupportRequest.new(support_params)
     if current_user
       @support_request.is_logged_in = true
@@ -49,6 +50,10 @@ class CommunitySupportController < ApplicationController
 
   def category_filters
     request.cookies['last_category_filters']
+  end
+
+  def toilet_filters
+    request.cookies['last_toilet_filters']
   end
 
   def form_params

--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -12,7 +12,8 @@ class CommunitySupportController < ApplicationController
                                        latitude: latitude,
                                        longitude: longitude,
                                        last_zoom_level: zoom_level,
-                                       status_filters: status_filters)
+                                       status_filters: status_filters,
+                                       category_filters: category_filters)
     @support_request = CommunitySupportRequest.new(support_params)
     if current_user
       @support_request.is_logged_in = true
@@ -44,6 +45,10 @@ class CommunitySupportController < ApplicationController
 
   def status_filters
     request.cookies['last_status_filters']
+  end
+
+  def category_filters
+    request.cookies['last_category_filters']
   end
 
   def form_params

--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -8,7 +8,10 @@ class CommunitySupportController < ApplicationController
   end
 
   def create
-    support_params = form_params.merge(user_agent: request.user_agent)
+    support_params = form_params.merge(user_agent: request.user_agent,
+                                       latitude: latitude,
+                                       longitude: longitude,
+                                       last_zoom_level: zoom_level)
     @support_request = CommunitySupportRequest.new(support_params)
     if current_user
       @support_request.is_logged_in = true
@@ -25,6 +28,18 @@ class CommunitySupportController < ApplicationController
   end
 
   private
+
+  def latitude
+    request.cookies['last_lat']
+  end
+
+  def longitude
+    request.cookies['last_lon']
+  end
+
+  def zoom_level
+    request.cookies['last_zoom']
+  end
 
   def form_params
     params.require(:community_support_request).permit(:name, :email, :message)

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -43,6 +43,8 @@ class CommunitySupportRequest
   def localize_status_filters(filters)
     return ['Alle aktiviert'] if filters.nil?
 
+    return ['Keine aktiv'] if filters.length == 0
+
     filters.map do |filter|
       case filter.downcase
       when 'yes'

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -1,7 +1,7 @@
 class CommunitySupportRequest
   include ActiveModel::Validations
   attr_accessor :name, :email, :message, :osm_username, :is_logged_in,
-    :last_zoom_level, :latitude, :longitude
+    :last_zoom_level, :latitude, :longitude, :status_filters
 
   validates_presence_of :name, :email, :message
   validates :email, format: { with: /@/ }
@@ -14,6 +14,7 @@ class CommunitySupportRequest
     @last_zoom_level = params.fetch(:last_zoom_level, nil) || 'N/A'
     @latitude = params.fetch(:latitude, nil) || 'N/A'
     @longitude = params.fetch(:longitude, nil) || 'N/A'
+    @status_filters = localize_status_filters(params.fetch(:status_filters, nil))
   end
 
   def browser_vendor
@@ -34,5 +35,24 @@ class CommunitySupportRequest
 
   def to_key
     nil
+  end
+
+  private
+
+  def localize_status_filters(filters)
+    return 'Alle aktiviert' if filters.nil?
+
+    filters.map do |filter|
+      case filter.downcase
+      when 'yes'
+        'Rollstuhlgerecht'
+      when 'no'
+        'Nicht rollstuhlgerecht'
+      when 'limited'
+        'Teilweise rollstuhlgerecht'
+      else
+        'Unbekannt'
+      end
+    end.join(', ')
   end
 end

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -1,6 +1,7 @@
 class CommunitySupportRequest
   include ActiveModel::Validations
-  attr_accessor :name, :email, :message, :osm_username, :is_logged_in
+  attr_accessor :name, :email, :message, :osm_username, :is_logged_in,
+    :last_zoom_level, :latitude, :longitude
 
   validates_presence_of :name, :email, :message
   validates :email, format: { with: /@/ }
@@ -10,6 +11,9 @@ class CommunitySupportRequest
     @email = params.fetch(:email, '')
     @message = params.fetch(:message, '')
     @user_agent = UserAgent.parse(params.fetch(:user_agent, ''))
+    @last_zoom_level = params.fetch(:last_zoom_level, '')
+    @latitude = params.fetch(:latitude, nil)
+    @longitude = params.fetch(:longitude, nil)
   end
 
   def browser_vendor

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -1,7 +1,7 @@
 class CommunitySupportRequest
   include ActiveModel::Validations
   attr_accessor :name, :email, :message, :osm_username, :is_logged_in,
-    :last_zoom_level, :latitude, :longitude, :status_filters
+    :last_zoom_level, :latitude, :longitude, :status_filters, :category_filters
 
   validates_presence_of :name, :email, :message
   validates :email, format: { with: /@/ }
@@ -15,6 +15,7 @@ class CommunitySupportRequest
     @latitude = params.fetch(:latitude, nil) || 'N/A'
     @longitude = params.fetch(:longitude, nil) || 'N/A'
     @status_filters = localize_status_filters(params.fetch(:status_filters, nil))
+    @category_filters = params.fetch(:category_filters, nil) || ['Alle aktiv']
   end
 
   def browser_vendor
@@ -40,7 +41,7 @@ class CommunitySupportRequest
   private
 
   def localize_status_filters(filters)
-    return 'Alle aktiviert' if filters.nil?
+    return ['Alle aktiviert'] if filters.nil?
 
     filters.map do |filter|
       case filter.downcase
@@ -53,6 +54,6 @@ class CommunitySupportRequest
       else
         'Unbekannt'
       end
-    end.join(', ')
+    end
   end
 end

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -11,9 +11,9 @@ class CommunitySupportRequest
     @email = params.fetch(:email, '')
     @message = params.fetch(:message, '')
     @user_agent = UserAgent.parse(params.fetch(:user_agent, ''))
-    @last_zoom_level = params.fetch(:last_zoom_level, '')
-    @latitude = params.fetch(:latitude, nil)
-    @longitude = params.fetch(:longitude, nil)
+    @last_zoom_level = params.fetch(:last_zoom_level, nil) || 'N/A'
+    @latitude = params.fetch(:latitude, nil) || 'N/A'
+    @longitude = params.fetch(:longitude, nil) || 'N/A'
   end
 
   def browser_vendor

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -1,7 +1,7 @@
 class CommunitySupportRequest
   include ActiveModel::Validations
   attr_accessor :name, :email, :message, :osm_username, :is_logged_in,
-    :last_zoom_level, :latitude, :longitude, :status_filters, :category_filters, :toilet_filters
+    :last_zoom_level, :latitude, :longitude, :wheelchair_status_filters, :category_filters, :toilet_filters
 
   validates_presence_of :name, :email, :message
   validates :email, format: { with: /@/ }
@@ -14,7 +14,7 @@ class CommunitySupportRequest
     @last_zoom_level = value_or_not_available(params.fetch(:last_zoom_level, nil))
     @latitude = value_or_not_available(params.fetch(:latitude, nil))
     @longitude = value_or_not_available(params.fetch(:longitude, nil))
-    @status_filters = localize_status_filters(params.fetch(:status_filters, nil))
+    @wheelchair_status_filters = localize_status_filters(params.fetch(:wheelchair_status_filters, nil))
     @category_filters = value_or_all_active(params.fetch(:category_filters, nil))
     @toilet_filters = localize_status_filters(params.fetch(:toilet_filters, nil))
   end

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -1,7 +1,7 @@
 class CommunitySupportRequest
   include ActiveModel::Validations
   attr_accessor :name, :email, :message, :osm_username, :is_logged_in,
-    :last_zoom_level, :latitude, :longitude, :status_filters, :category_filters
+    :last_zoom_level, :latitude, :longitude, :status_filters, :category_filters, :toilet_filters
 
   validates_presence_of :name, :email, :message
   validates :email, format: { with: /@/ }
@@ -16,6 +16,7 @@ class CommunitySupportRequest
     @longitude = params.fetch(:longitude, nil) || 'N/A'
     @status_filters = localize_status_filters(params.fetch(:status_filters, nil))
     @category_filters = params.fetch(:category_filters, nil) || ['Alle aktiv']
+    @toilet_filters = localize_status_filters(params.fetch(:toilet_filters, nil))
   end
 
   def browser_vendor

--- a/app/models/community_support_request.rb
+++ b/app/models/community_support_request.rb
@@ -11,11 +11,11 @@ class CommunitySupportRequest
     @email = params.fetch(:email, '')
     @message = params.fetch(:message, '')
     @user_agent = UserAgent.parse(params.fetch(:user_agent, ''))
-    @last_zoom_level = params.fetch(:last_zoom_level, nil) || 'N/A'
-    @latitude = params.fetch(:latitude, nil) || 'N/A'
-    @longitude = params.fetch(:longitude, nil) || 'N/A'
+    @last_zoom_level = value_or_not_available(params.fetch(:last_zoom_level, nil))
+    @latitude = value_or_not_available(params.fetch(:latitude, nil))
+    @longitude = value_or_not_available(params.fetch(:longitude, nil))
     @status_filters = localize_status_filters(params.fetch(:status_filters, nil))
-    @category_filters = params.fetch(:category_filters, nil) || ['Alle aktiv']
+    @category_filters = value_or_all_active(params.fetch(:category_filters, nil))
     @toilet_filters = localize_status_filters(params.fetch(:toilet_filters, nil))
   end
 
@@ -40,6 +40,22 @@ class CommunitySupportRequest
   end
 
   private
+
+  def value_or_not_available(value)
+    if value
+      value
+    else
+      'N/A'
+    end
+  end
+
+  def value_or_all_active(filters)
+    if filters
+      filters
+    else
+      ["Alle aktiv"]
+    end
+  end
 
   def localize_status_filters(filters)
     return ['Alle aktiviert'] if filters.nil?

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -7,7 +7,7 @@ Browser Version: <%= @community_support_request.browser_version %>
 Zoom level: <%= @community_support_request.last_zoom_level %>
 Latitude: <%= @community_support_request.latitude %>
 Longitude: <%= @community_support_request.longitude %>
-Rollstuhlfilter: <%= @community_support_request.status_filters.join(', ') %>
+Rollstuhlfilter: <%= @community_support_request.wheelchair_status_filters.join(', ') %>
 <% if @community_support_request.category_filters.length > 0 %>
 Kategorien: <%= @community_support_request.category_filters.join(', ') %>
 <% else %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -7,8 +7,8 @@ Browser Version: <%= @community_support_request.browser_version %>
 Zoom level: <%= @community_support_request.last_zoom_level %>
 Latitude: <%= @community_support_request.latitude %>
 Longitude: <%= @community_support_request.longitude %>
-Rollstuhlfilter: <%= @community_support_request.status_filters %>
-Kategorien: Alle aktiv
+Rollstuhlfilter: <%= @community_support_request.status_filters.join(', ') %>
+Kategorien: <%= @community_support_request.category_filters.join(', ') %>
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -7,6 +7,7 @@ Browser Version: <%= @community_support_request.browser_version %>
 Zoom level: <%= @community_support_request.last_zoom_level %>
 Latitude: <%= @community_support_request.latitude %>
 Longitude: <%= @community_support_request.longitude %>
+Rollstuhlfilter: <%= @community_support_request.status_filters %>
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -4,6 +4,9 @@ Betriebssystem Hersteller: <%= @community_support_request.operating_system %>
 Betriebssystem Version: <%= @community_support_request.operating_system_version %>
 Browser Hersteller: <%= @community_support_request.browser_vendor %>
 Browser Version: <%= @community_support_request.browser_version %>
+Zoom level: <%= @community_support_request.last_zoom_level %>
+Latitude: <%= @community_support_request.latitude %>
+Longitude: <%= @community_support_request.longitude %>
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -8,7 +8,11 @@ Zoom level: <%= @community_support_request.last_zoom_level %>
 Latitude: <%= @community_support_request.latitude %>
 Longitude: <%= @community_support_request.longitude %>
 Rollstuhlfilter: <%= @community_support_request.status_filters.join(', ') %>
+<% if @community_support_request.category_filters.length > 0 %>
 Kategorien: <%= @community_support_request.category_filters.join(', ') %>
+<% else %>
+Kategorien: Keine ausgewählt
+<% end %>
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -8,6 +8,7 @@ Zoom level: <%= @community_support_request.last_zoom_level %>
 Latitude: <%= @community_support_request.latitude %>
 Longitude: <%= @community_support_request.longitude %>
 Rollstuhlfilter: <%= @community_support_request.status_filters %>
+Kategorien: Alle aktiv
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/app/views/community_support_mailer/send_to_support_team.text.erb
+++ b/app/views/community_support_mailer/send_to_support_team.text.erb
@@ -13,6 +13,7 @@ Kategorien: <%= @community_support_request.category_filters.join(', ') %>
 <% else %>
 Kategorien: Keine ausgewählt
 <% end %>
+WC: <%= @community_support_request.toilet_filters.join(", ") %>
 <% if @community_support_request.is_logged_in %>
 BenutzerIn ist eingeloggt mit: <%= @community_support_request.email %>
 OSM Username: <%= @community_support_request.osm_username %>

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -201,6 +201,26 @@ RSpec.describe CommunitySupportController, type: :controller do
       end
     end
 
+    context 'with valid form params cookie set and partially selected categories' do
+      before do
+        ActionMailer::Base.deliveries.clear
+        @current_locale = I18n.locale
+        allow(request).to receive(:user_agent).and_return(user_agent)
+        params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+        request.cookies['last_category_filters'] = ["money_post","government","shopping","food"]
+        post :create, params
+      end
+
+      describe "email body" do
+        let(:last_delivery) { ActionMailer::Base.deliveries.last }
+        let(:raw_body) { last_delivery.body.raw_source }
+
+        it "indicates which category filters are enabled" do
+          expect(raw_body).to include("Kategorien: money_post, government, shopping, food")
+        end
+      end
+    end
+
     context "with invalid form params" do
       before do
         ActionMailer::Base.deliveries.clear

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -141,6 +141,38 @@ RSpec.describe CommunitySupportController, type: :controller do
       end
     end
 
+    context 'with valid form params but without cookie set' do
+      before do
+        ActionMailer::Base.deliveries.clear
+        @current_locale = I18n.locale
+        I18n.locale = :en
+        allow(request).to receive(:user_agent).and_return(user_agent)
+        params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+        post :create, params
+      end
+
+      after do
+        I18n.locale = @current_locale
+      end
+
+      describe "email body" do
+        let(:last_delivery) { ActionMailer::Base.deliveries.last }
+        let(:raw_body) { last_delivery.body.raw_source }
+
+        it "contains empty latitude" do
+          expect(raw_body).to include("Latitude: N/A")
+        end
+
+        it "contains empty last zoom level" do
+          expect(raw_body).to include("Zoom level: N/A")
+        end
+
+        it "contains empty longitude" do
+          expect(raw_body).to include("Longitude: N/A")
+        end
+      end
+    end
+
     context "with invalid form params" do
       before do
         ActionMailer::Base.deliveries.clear

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -204,19 +204,38 @@ RSpec.describe CommunitySupportController, type: :controller do
     context 'with valid form params cookie set and partially selected categories' do
       before do
         ActionMailer::Base.deliveries.clear
-        @current_locale = I18n.locale
         allow(request).to receive(:user_agent).and_return(user_agent)
-        params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-        request.cookies['last_category_filters'] = ["money_post","government","shopping","food"]
-        post :create, params
       end
 
-      describe "email body" do
-        let(:last_delivery) { ActionMailer::Base.deliveries.last }
-        let(:raw_body) { last_delivery.body.raw_source }
+      context 'with some selected' do
+        before do
+          params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+          request.cookies['last_category_filters'] = ["money_post","government","shopping","food"]
+          post :create, params
+        end
+        describe "email body" do
+          let(:last_delivery) { ActionMailer::Base.deliveries.last }
+          let(:raw_body) { last_delivery.body.raw_source }
 
-        it "indicates which category filters are enabled" do
-          expect(raw_body).to include("Kategorien: money_post, government, shopping, food")
+          it "indicates which category filters are enabled" do
+            expect(raw_body).to include("Kategorien: money_post, government, shopping, food")
+          end
+        end
+      end
+
+      context 'with none selected' do
+        before do
+          params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+          request.cookies['last_category_filters'] = []
+          post :create, params
+        end
+        describe "email body" do
+          let(:last_delivery) { ActionMailer::Base.deliveries.last }
+          let(:raw_body) { last_delivery.body.raw_source }
+
+          it "indicates which category filters are enabled" do
+            expect(raw_body).to include("Kategorien: Keine ausgewählt")
+          end
         end
       end
     end

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -181,22 +181,43 @@ RSpec.describe CommunitySupportController, type: :controller do
       end
     end
 
-    context 'with valid form params cookie set and partially disabled wheelchair filters' do
+    context 'with valid form params cookie set and wheelchair filters' do
       before do
         ActionMailer::Base.deliveries.clear
-        @current_locale = I18n.locale
         allow(request).to receive(:user_agent).and_return(user_agent)
-        params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-        request.cookies['last_status_filters'] = ["unknown", "yes"]
-        post :create, params
       end
 
-      describe 'email body' do
-        let(:last_delivery) { ActionMailer::Base.deliveries.last }
-        let(:raw_body) { last_delivery.body.raw_source }
+      context 'with partially enabled filters' do
+        before do
+          params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+          request.cookies['last_status_filters'] = ["unknown", "yes"]
+          post :create, params
+        end
 
-        it "indicates which filters are enabled" do
-          expect(raw_body).to include("Rollstuhlfilter: Unbekannt, Rollstuhlgerecht")
+        describe 'email body' do
+          let(:last_delivery) { ActionMailer::Base.deliveries.last }
+          let(:raw_body) { last_delivery.body.raw_source }
+
+          it "indicates which filters are enabled" do
+            expect(raw_body).to include("Rollstuhlfilter: Unbekannt, Rollstuhlgerecht")
+          end
+        end
+      end
+
+      context 'with all filters disabled' do
+        before do
+          params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+          request.cookies['last_status_filters'] = []
+          post :create, params
+        end
+
+        describe 'email body' do
+          let(:last_delivery) { ActionMailer::Base.deliveries.last }
+          let(:raw_body) { last_delivery.body.raw_source }
+
+          it "says that none are active" do
+            expect(raw_body).to include("Rollstuhlfilter: Keine aktiv")
+          end
         end
       end
     end

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with partially enabled filters' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_status_filters'] = ["unknown", "yes"]
+          request.cookies['last_status_filters'] = ["unknown", "yes"].to_json
           post :create, params
         end
 
@@ -211,7 +211,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with all filters disabled' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_status_filters'] = []
+          request.cookies['last_status_filters'] = [].to_json
           post :create, params
         end
 
@@ -235,7 +235,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with some selected' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_category_filters'] = ["money_post","government","shopping","food"]
+          request.cookies['last_category_filters'] = ["money_post","government","shopping","food"].to_json
           post :create, params
         end
         describe "email body" do
@@ -251,7 +251,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with none selected' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_category_filters'] = []
+          request.cookies['last_category_filters'] = [].to_json
           post :create, params
         end
         describe "email body" do
@@ -274,7 +274,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with some selected' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_toilet_filters'] = ["yes", "unknown"]
+          request.cookies['last_toilet_filters'] = ["yes", "unknown"].to_json
           post :create, params
         end
 
@@ -291,7 +291,7 @@ RSpec.describe CommunitySupportController, type: :controller do
       context 'with none selected' do
         before do
           params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
-          request.cookies['last_toilet_filters'] = []
+          request.cookies['last_toilet_filters'] = [].to_json
           post :create, params
         end
 

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -287,6 +287,23 @@ RSpec.describe CommunitySupportController, type: :controller do
           end
         end
       end
+
+      context 'with none selected' do
+        before do
+          params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+          request.cookies['last_toilet_filters'] = []
+          post :create, params
+        end
+
+        describe "email body" do
+          let(:last_delivery) { ActionMailer::Base.deliveries.last }
+          let(:raw_body) { last_delivery.body.raw_source }
+
+          it "indicates which category filters are enabled" do
+            expect(raw_body).to include("WC: Keine aktiv")
+          end
+        end
+      end
     end
 
     context "with invalid form params" do

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe CommunitySupportController, type: :controller do
           expect(raw_body).to include("Rollstuhlfilter: Alle aktiviert")
         end
 
+        it "says that all categories are enabled" do
+          expect(raw_body).to include("Kategorien: Alle aktiv")
+        end
+
         describe "the user agent" do
           it "has correct operating system vendor" do
             expect(raw_body).to include("Betriebssystem Hersteller: Macintosh")

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe CommunitySupportController, type: :controller do
     let(:user_agent) { 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0' }
     let(:osm_username) { 'lisa maier' }
     let(:current_user) { FactoryGirl.create(:user, :email => email, :oauth_token =>'token', :oauth_secret => 'secret', osm_username: osm_username) }
+    let(:latitude)        { 52.50327542986572 }
+    let(:longitude)       { 13.411503732204435 }
+    let(:last_zoom_level) { 15 }
 
     context "with valid form params and user not logged in" do
       before do
@@ -25,6 +28,9 @@ RSpec.describe CommunitySupportController, type: :controller do
         I18n.locale = :en
         allow(request).to receive(:user_agent).and_return(user_agent)
         params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message }}
+        request.cookies['last_lat'] = latitude
+        request.cookies['last_lon'] = longitude
+        request.cookies['last_zoom'] = last_zoom_level
         post :create, params
       end
 
@@ -78,6 +84,18 @@ RSpec.describe CommunitySupportController, type: :controller do
 
         it "does not contain the user's osm username" do
           expect(raw_body).to_not include("OSM Username: #{osm_username}")
+        end
+
+        it "contains the last zoom level" do
+          expect(raw_body).to include("Zoom level: #{last_zoom_level}")
+        end
+
+        it "contains the last latitude" do
+          expect(raw_body).to include("Latitude: #{latitude}")
+        end
+
+        it "contains the last longitude" do
+          expect(raw_body).to include("Longitude: #{longitude}")
         end
 
         describe "the user agent" do


### PR DESCRIPTION
Follow up for #370 
Also resolves #370 

This gathers all missing data from a user:

- Latitude
- Longitude
- Last zoom level
- selected wheelchair filters
- selected toilet filters
- selected categories

These information are read from the user's cookie. This means if the user configured their browser to not have cookies we cannot get these information.