### PR TITLE
Feature/send delayed email to support team

### DIFF
--- a/app/controllers/community_support_controller.rb
+++ b/app/controllers/community_support_controller.rb
@@ -22,7 +22,7 @@ class CommunitySupportController < ApplicationController
     end
 
     if @support_request.valid?
-      CommunitySupportMailer.send_to_support_team(@support_request).deliver
+      CommunitySupportMailer.delay.send_to_support_team(@support_request)
       flash[:notice] = I18n.t('community_support_form.new.form.flash_after_submit')
       redirect_to root_path
     else

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe CommunitySupportController, type: :controller do
       Delayed::Worker.delay_jobs = false
     end
 
+    after do
+      Delayed::Worker.delay_jobs = true
+    end
+
     context "with valid form params and user not logged in" do
       before do
         @current_locale = I18n.locale

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -316,10 +316,6 @@ RSpec.describe CommunitySupportController, type: :controller do
         params
       end
 
-      after do
-        I18n.locale = @current_locale
-      end
-
       it "enqueues an email to send later to the support team" do
         submit
         expect(Delayed::Job.count).to eq(1)

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -161,7 +161,6 @@ RSpec.describe CommunitySupportController, type: :controller do
 
     context 'with valid form params but without cookie set' do
       before do
-        # ActionMailer::Base.deliveries.clear
         @current_locale = I18n.locale
         I18n.locale = :en
         allow(request).to receive(:user_agent).and_return(user_agent)
@@ -192,7 +191,6 @@ RSpec.describe CommunitySupportController, type: :controller do
 
     context 'with valid form params cookie set and wheelchair filters' do
       before do
-        ActionMailer::Base.deliveries.clear
         allow(request).to receive(:user_agent).and_return(user_agent)
       end
 

--- a/spec/controllers/community_support_controller_spec.rb
+++ b/spec/controllers/community_support_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CommunitySupportController, type: :controller do
     let(:latitude)        { 52.50327542986572 }
     let(:longitude)       { 13.411503732204435 }
     let(:last_zoom_level) { 15 }
-    let(:params) { params = {:community_support_request => { name: user_name, email: "holger@example.com", message: message}}}
+    let(:params) { { :community_support_request => { name: user_name, email: "holger@example.com", message: message}} }
 
     before do
       ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
At the moment we trigger to send an email to the support team after the community support form submission. To prevent other performances being blocked by this, we have to enqueque and deliver those mails at a later time. This PR uses the simplest way to deliver delayed emails working for versions before Rails 4.2.

Resolves Github issue:
#496
