### PR TITLE
DB/add measurement migration

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -568,7 +568,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-02 14:43:26
+-- Dump completed on 2016-12-13  9:54:15
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -714,4 +714,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161017134327');
 INSERT INTO schema_migrations (version) VALUES ('20161017135542');
 
 INSERT INTO schema_migrations (version) VALUES ('20161021141630');
+
+INSERT INTO schema_migrations (version) VALUES ('20161128102235');
 


### PR DESCRIPTION
When running the rspec tests on my machine I experienced a failure at `expect(measurement.description).to be nil`. After a check we realized that the latest migration was missing where the default's value was set to NULL when no description was given.

This PR checks in that missing migration. 