### PR TITLE
Move all navigation code into try block

### DIFF
--- a/app/assets/javascripts/NewNodeWidget/sagas/__tests__/navigateToNextSection.js
+++ b/app/assets/javascripts/NewNodeWidget/sagas/__tests__/navigateToNextSection.js
@@ -21,7 +21,7 @@ describe('navigateToNextSection', () => {
     expect(gen.next())
       .toSelect(selectors.node);
 
-    const node = new Node({name: 'gartenbank', lat: 52.5226074, lon: 13.2874013});
+    const node = new Node({ name: 'gartenbank', lat: 52.5226074, lon: 13.2874013 });
 
     expect(gen.next(node))
       .toSelect(selectors.activeSection);

--- a/app/assets/javascripts/NewNodeWidget/sagas/__tests__/navigateToNextSection.js
+++ b/app/assets/javascripts/NewNodeWidget/sagas/__tests__/navigateToNextSection.js
@@ -9,6 +9,7 @@ import { NAME_CATEGORY, ADDRESS } from '../../models/sections';
 import navigateToNextSection from '../navigateToNextSection';
 
 jest.unmock('../navigateToNextSection');
+jest.unmock('../../../common/models/Node');
 
 describe('navigateToNextSection', () => {
   it('navigates to next section', () => {
@@ -20,7 +21,7 @@ describe('navigateToNextSection', () => {
     expect(gen.next())
       .toSelect(selectors.node);
 
-    const node = new Node();
+    const node = new Node({name: 'gartenbank', lat: 52.5226074, lon: 13.2874013});
 
     expect(gen.next(node))
       .toSelect(selectors.activeSection);
@@ -39,9 +40,6 @@ describe('navigateToNextSection', () => {
     expect(gen.next(attrs))
       .toCall(validateNode, node, attrs);
 
-    expect(gen.next())
-      .toPut(load(false));
-
     expect(gen.next(node))
       .toSelect(selectors.sections);
 
@@ -49,6 +47,9 @@ describe('navigateToNextSection', () => {
 
     expect(gen.next(sections))
       .toPut(push.newNodeSectionPath(ADDRESS, node.serialize()));
+
+    expect(gen.next())
+      .toPut(load(false));
 
     expect(gen.next().done)
       .toBe(false);

--- a/app/assets/javascripts/NewNodeWidget/sagas/navigateToNextSection.js
+++ b/app/assets/javascripts/NewNodeWidget/sagas/navigateToNextSection.js
@@ -20,6 +20,12 @@ export default function* navigateToNextSection() {
 
     try {
       yield call(validateNode, node, attrs);
+
+      const sections = yield select(selectors.sections);
+      const nextIndex = sections.indexOf(activeSection) + 1;
+      const nextSection = sections.get(nextIndex);
+
+      yield put(push.newNodeSectionPath(nextSection, node.serialize()));
     } catch (error) {
       if (yield call(HTTPError.is, error, 422)) {
         const { errors } = error;
@@ -32,11 +38,5 @@ export default function* navigateToNextSection() {
     } finally {
       yield put(load(false));
     }
-
-    const sections = yield select(selectors.sections);
-    const nextIndex = sections.indexOf(activeSection) + 1;
-    const nextSection = sections.get(nextIndex);
-
-    yield put(push.newNodeSectionPath(nextSection, node.serialize()));
   }
 }


### PR DESCRIPTION
Resolves #483 
This prevents navigation forward when the validation failed. Before the user didn't have the chance to correct what was wrong and where immediately taken on the next page.

/cc @lennerd 