### PR TITLE
Fix/adapt regex for regional locales

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,8 +67,8 @@ module ApplicationHelper
       uri.path = "/#{locale}/"
     elsif uri.path =~ /^\/tlh($|\/)/
       uri.path = uri.path.gsub(/^\/tlh($|\/)/, "/#{locale}/")
-    elsif uri.path =~ /^\/[a-z]{2}(-[a-zA-Z]{2})?($|\/)/ #/pt-TR/
-      uri.path = uri.path.gsub(/^\/\w{2}(-\w{2})?($|\/)/, "/#{locale}/")
+    elsif uri.path =~ /^\/[a-z]{2}(_[a-zA-Z]{2})?($|\/)/ # e.g. /pt-BR/
+      uri.path = uri.path.gsub(/^\/\w{2}(_\w{2})?($|\/)/, "/#{locale}/")
     else
       uri.path = uri.path.gsub(/^(.+?)$/, "/#{locale}" + '\1')
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,8 +67,8 @@ module ApplicationHelper
       uri.path = "/#{locale}/"
     elsif uri.path =~ /^\/tlh($|\/)/
       uri.path = uri.path.gsub(/^\/tlh($|\/)/, "/#{locale}/")
-    elsif uri.path =~ /^\/[a-z]{2}(_[a-zA-Z]{2})?($|\/)/ # e.g. /pt-BR/
-      uri.path = uri.path.gsub(/^\/\w{2}(_\w{2})?($|\/)/, "/#{locale}/")
+    elsif uri.path =~ /^\/[a-z]{2}(_[a-zA-Z]{2})?($|\/)/ # e.g. "/pt_BR/"
+      uri.path = uri.path.gsub(/^\/[a-z]{2}(_[a-zA-Z]{2})?($|\/)/, "/#{locale}/")
     else
       uri.path = uri.path.gsub(/^(.+?)$/, "/#{locale}" + '\1')
     end

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -24,6 +24,31 @@ describe "Locale feature" do
     I18n.locale = I18n.default_locale
   end
 
+  describe "switching from a locale containing underscore to a locale without", feature: true, js: true do
+    before do
+      visit "/pt_BR/map"
+      # There's a popup the first time we visit wheelmap.
+      # That needs to be clicked away first
+      using_wait_time 30 do
+        find('button.go').click
+      end
+      using_wait_time 10 do
+        find('.language-select').click
+      end
+      find("a", text: /\AEspañol\z/).click
+    end
+
+    after do
+      browser = Capybara.current_session.driver.browser
+      Rack::MockSession
+      browser.clear_cookies
+    end
+
+    it "loads correct locale path" do
+      expect(current_path).to match("/es/map")
+    end
+  end
+
   describe "Languages in wheelmap" do
     before do
       Capybara.current_session.driver.header("Accept-Language", SUPPORTED_LANGUAGES)

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -72,6 +72,3 @@ describe "Locale feature" do
     it_behaves_like "switch language manually", "zh_TW", '/zh_TW'
   end
 end
-
-
-# ar;bg;cs;da;de;el;en;es;fr;hu;is;it;ja;ko;lv;pl;pt;pt_BR;ru;sk;sv;tlh;tr;zh_TW

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-SUPPORTED_LANGUAGES = "de;en;es;fr;it;is"
+SUPPORTED_LANGUAGES = "ar;bg;cs;da;de;el;en;es;fr;hu;is;it;ja;ko;lv;pl;pt;pt_BR;ru;sk;sv;tlh;tr;zh_TW"
 
 shared_examples "switch language manually" do |language, url|
   describe "Switch language manually to #{language}" do
@@ -47,7 +47,31 @@ describe "Locale feature" do
     end
 
     it_behaves_like "switch language manually", "de", '/map'
-    it_behaves_like "switch language manually", "es", '/es'
     it_behaves_like "switch language manually", "en", '/en'
+    it_behaves_like "switch language manually", "ar", '/ar'
+    it_behaves_like "switch language manually", "bg", '/bg'
+    it_behaves_like "switch language manually", "cs", '/cs'
+    it_behaves_like "switch language manually", "da", '/da'
+    it_behaves_like "switch language manually", "el", '/el'
+    it_behaves_like "switch language manually", "es", '/es'
+    it_behaves_like "switch language manually", "fr", '/fr'
+    it_behaves_like "switch language manually", "hu", '/hu'
+    it_behaves_like "switch language manually", "is", '/is'
+    it_behaves_like "switch language manually", "it", '/it'
+    it_behaves_like "switch language manually", "ja", '/ja'
+    it_behaves_like "switch language manually", "ko", '/ko'
+    it_behaves_like "switch language manually", "lv", '/lv'
+    it_behaves_like "switch language manually", "pl", '/pl'
+    it_behaves_like "switch language manually", "pt", '/pt'
+    it_behaves_like "switch language manually", "pt_BR", '/pt_BR'
+    it_behaves_like "switch language manually", "ru", '/ru'
+    it_behaves_like "switch language manually", "sk", '/sk'
+    it_behaves_like "switch language manually", "sv", '/sv'
+    it_behaves_like "switch language manually", "tlh", '/tlh'
+    it_behaves_like "switch language manually", "tr", '/tr'
+    it_behaves_like "switch language manually", "zh_TW", '/zh_TW'
   end
 end
+
+
+# ar;bg;cs;da;de;el;en;es;fr;hu;is;it;ja;ko;lv;pl;pt;pt_BR;ru;sk;sv;tlh;tr;zh_TW


### PR DESCRIPTION
The helper method [url_for_locale](https://github.com/sozialhelden/wheelmap/blob/master/app/helpers/application_helper.rb#L63-L78) tries to catch `pt-BR` while `pt_BR` is being used in wheelmap as regional locale pattern. Means when trying to switch e.g. from `/pt_BR/map` to Spanish the path would be `es/pt_BR/map` which causes `404 - not found`.

This PR corrects that pattern and adds some tests for missing locales.

Fixes Github issue: #519 