### PR TITLE
Fix toilet unknown bug

### DIFF
--- a/app/jobs/create_node_job.rb
+++ b/app/jobs/create_node_job.rb
@@ -1,7 +1,7 @@
 require 'htmlentities'
 class CreateNodeJob < Struct.new(:lat, :lon, :tags, :user, :client, :source)
-  WHEELCHAIR_TAG_KEY = 'wheelchair'
-  WHEELCHAIR_TOILET_TAG_KEY = 'toilets:wheelchair'
+  WHEELCHAIR_TAG_KEY = "wheelchair"
+  WHEELCHAIR_TOILET_TAG_KEY = "toilets:wheelchair"
 
   def self.enqueue(lat, lon, tags, user, source)
     raise "user not app authorized" unless user.app_authorized? # implies user.access_token.present?
@@ -10,7 +10,7 @@ class CreateNodeJob < Struct.new(:lat, :lon, :tags, :user, :client, :source)
     return unless Rails.env.production? || Rails.env.test?
 
     # Remove wheelchair tag if value is "unknown"
-    tags.delete(WHEELCHAIR_TAG_KEY) if tags[WHEELCHAIR_TAG_KEY] == 'unknown'
+    tags.delete(WHEELCHAIR_TAG_KEY) if tags[WHEELCHAIR_TAG_KEY] == "unknown"
     tags.delete(WHEELCHAIR_TOILET_TAG_KEY) if tags[WHEELCHAIR_TOILET_TAG_KEY] == "unknown"
 
     client = Rosemary::OauthClient.new(user.access_token)

--- a/app/jobs/create_node_job.rb
+++ b/app/jobs/create_node_job.rb
@@ -1,5 +1,7 @@
 require 'htmlentities'
 class CreateNodeJob < Struct.new(:lat, :lon, :tags, :user, :client, :source)
+  WHEELCHAIR_TAG_KEY = 'wheelchair'
+  WHEELCHAIR_TOILET_TAG_KEY = 'toilets:wheelchair'
 
   def self.enqueue(lat, lon, tags, user, source)
     raise "user not app authorized" unless user.app_authorized? # implies user.access_token.present?
@@ -8,8 +10,8 @@ class CreateNodeJob < Struct.new(:lat, :lon, :tags, :user, :client, :source)
     return unless Rails.env.production? || Rails.env.test?
 
     # Remove wheelchair tag if value is "unknown"
-    tags.delete("wheelchair") if tags["wheelchair"] == 'unknown'
-    tags.delete("toilets:wheelchair") if tags["toilets:wheelchair"] == "unknown"
+    tags.delete(WHEELCHAIR_TAG_KEY) if tags[WHEELCHAIR_TAG_KEY] == 'unknown'
+    tags.delete(WHEELCHAIR_TOILET_TAG_KEY) if tags[WHEELCHAIR_TOILET_TAG_KEY] == "unknown"
 
     client = Rosemary::OauthClient.new(user.access_token)
 

--- a/app/jobs/create_node_job.rb
+++ b/app/jobs/create_node_job.rb
@@ -9,6 +9,7 @@ class CreateNodeJob < Struct.new(:lat, :lon, :tags, :user, :client, :source)
 
     # Remove wheelchair tag if value is "unknown"
     tags.delete("wheelchair") if tags["wheelchair"] == 'unknown'
+    tags.delete("toilets:wheelchair") if tags["toilets:wheelchair"] == "unknown"
 
     client = Rosemary::OauthClient.new(user.access_token)
 

--- a/spec/jobs/create_node_job_spec.rb
+++ b/spec/jobs/create_node_job_spec.rb
@@ -88,7 +88,7 @@ describe CreateNodeJob do
       CreateNodeJob.enqueue(52.4, 13.0, { 'wheelchair' => 'unknown', 'toilets:wheelchair' => 'unknown', 'amenity' => 'bar', 'name' => 'White horse' }, user, 'create_iphone')
     }
 
-    it "does not save wheelchair tag" do
+    it "does not save wheelchair and toilet:wheelchair tag" do
 
       api = double(:find_or_create_open_changeset => changeset)
       expect(Rosemary::Api).to receive(:new).and_return(api)

--- a/spec/jobs/create_node_job_spec.rb
+++ b/spec/jobs/create_node_job_spec.rb
@@ -85,7 +85,7 @@ describe CreateNodeJob do
   context "unknown value" do
 
     subject {
-      CreateNodeJob.enqueue(52.4, 13.0, { 'wheelchair' => 'unknown', 'amenity' => 'bar', 'name' => 'White horse' }, user, 'create_iphone')
+      CreateNodeJob.enqueue(52.4, 13.0, { 'wheelchair' => 'unknown', 'toilets:wheelchair' => 'unknown', 'amenity' => 'bar', 'name' => 'White horse' }, user, 'create_iphone')
     }
 
     it "does not save wheelchair tag" do
@@ -97,6 +97,7 @@ describe CreateNodeJob do
         expect(node.lat).to eql 52.4
         expect(node.lon).to eql 13.0
         expect(node.tags['wheelchair']).to be_nil
+        expect(node.tags['toilets:wheelchair']).to be_nil
         expect(node.tags['amenity']).to eq 'bar'
         expect(node.tags['name']).to eq 'White horse'
       end


### PR DESCRIPTION
Resolves #492 

This prevents that unknown toilet status is being transmitted to Openstreetmap. This is already in place for the wheelchair status.