### PR TITLE
Correct upload symlink

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,7 +76,7 @@ namespace :deploy do
 
         # We need to link the existing shared `/var/apps/wheelmap/public/system` folder
         # into the new release.
-	      execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/"
+        execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/"
 
         # We create this file so the consul health check will pass. We can't use an
         # existing file since they are all unpredictably named.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,7 +76,7 @@ namespace :deploy do
 
         # We need to link the existing shared `/var/apps/wheelmap/public/system` folder
         # into the new release.
-        execute :ln, "-s", "#{deploy_path}/public/system/uploads", "#{release_path}/public/system"
+	      execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/"
 
         # We create this file so the consul health check will pass. We can't use an
         # existing file since they are all unpredictably named.


### PR DESCRIPTION
#445 seems to have had an issue. If you deployed multiple times it seemed to do the linking incorrect. This makes the behavior more consistent.