### PR TITLE
Render link to travelable.info only if user has German locale selected

### DIFF
--- a/app/views/relaunch/_header.html.haml
+++ b/app/views/relaunch/_header.html.haml
@@ -41,7 +41,8 @@
           .list-wrapper
             %ul.inline
               %li= link_to t('header.navigation.map', :default => :en), root_path
-              %li= link_to t('header.navigation.travelguide', :default => :en), community_travelguide_url
+              - if I18n.locale == :de
+                %li= link_to t('header.navigation.travelguide', :default => :en), community_travelguide_url
               %li= link_to t('header.navigation.projects', :default => :en), community_projects_url
               %li= link_to t('header.navigation.blog', :default => :en), community_blog_url
               %li= link_to t('header.navigation.press', :default => :en), community_press_url


### PR DESCRIPTION
Related to #522 
As requested we render the link to `travelable.info` only if the user has selected the German locale.