### PR TITLE
Bring back the 'alert' key for node photos upload

### DIFF
--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -2,8 +2,8 @@
   %h2=t('.photos_of_this_place')
   - if user_signed_in? && current_user.terms?
     .alert.alert-icon
-      = fa_icon 'exclamation-sign'
-      = t('.alert')
+      = fa_icon "exclamation"
+      = t('nodes.node_photos.alert')
   =semantic_form_for([@node, Photo.new], url: node_photos_url(@node), html: { class: 'node-photo-dropzone', id: 'node-photo-dropzone', multipart: true }) do |form|
     %ul
       = list_of(node_photos.photos.reject{|photo| photo.new_record?}) do |photo|

--- a/app/views/nodes/_node_photos.html.haml
+++ b/app/views/nodes/_node_photos.html.haml
@@ -2,7 +2,7 @@
   %h2=t('.photos_of_this_place')
   - if user_signed_in? && current_user.terms?
     .alert.alert-icon
-      = fa_icon "exclamation"
+      = fa_icon 'exclamation-sign'
       = t('nodes.node_photos.alert')
   =semantic_form_for([@node, Photo.new], url: node_photos_url(@node), html: { class: 'node-photo-dropzone', id: 'node-photo-dropzone', multipart: true }) do |form|
     %ul

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -103,6 +103,7 @@ de:
       add: Hinzufügen
       photos_of_this_place: 'Fotos von diesem Ort:'
       upload: Hochladen
+      alert: 'Bitte beachte: Auf dem Foto sollte der Eingangsbereich des Ortes gut zu erkennen sein. Soll heißen: Gibt es Stufen am Eingang? Wie hoch ist die Stufe ungefähr? Wie breit ist die Tür? Das Foto muss das Format JPG oder PNG haben. Die maximale Größe eines Fotos darf 10 MB nicht überschreiten.'
     node_similar:
       similar: 'Ähnliche Orte: %{name}'
     node_status:

--- a/config/locales/en/relaunch.yml
+++ b/config/locales/en/relaunch.yml
@@ -103,6 +103,7 @@ en:
       add: Add
       photos_of_this_place: 'Photos of this place:'
       upload: Upload
+      alert: 'Please note: The entrance should be clearly visible in the photo in order to show the following: Are there steps at the entrance? Approximately how high is the step? How wide is the door? The photograph must be in a JPG or PNG format. It should not be larger than 10 MB.'
     node_similar:
       similar: 'Similar places: %{name}'
     node_status:


### PR DESCRIPTION
This PR fixes the missing alert info for users (before uploading an image on a node) and provides the initial text in DE and EN.

**Result:**
<img width="1265" alt="00000239" src="https://cloud.githubusercontent.com/assets/4077916/21810732/465e02ec-d74d-11e6-955f-724bc598ae15.png">


**Related Github issues:**
- https://github.com/sozialhelden/wheelmap/issues/497
- https://github.com/sozialhelden/wheelmap/pull/327 (previously merged to master but finally not in master anymore)

