### PR TITLE
Integrate with make_osc & deploy on osm-database

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :pty, true
 # Default value for :linked_files is []
 set :linked_files, %w{ config/database.yml config/open_street_map.yml config/metrics.yml config/librato.yml config/newrelic.yml .env config/secrets.yml}
 
-set :bundle_roles, [:app, :worker]
+set :bundle_roles, [:app, :worker, :importer]
 set :bundle_without, %w{ development test metrics deployment }.join(' ')
 set :bundle_jobs, 4
 set :bundle_binstubs, -> { shared_path.join('bin') }
@@ -75,7 +75,7 @@ namespace :deploy do
 
         # We need to link the existing shared `/var/apps/wheelmap/public/system` folder
         # into the new release.
-        execute :ln, "-s", "#{deploy_path}/public/system", "#{release_path}/public/"
+        execute :ln, "-s", "#{deploy_path}/public/system/uploads", "#{release_path}/public/system"
 
         # We create this file so the consul health check will pass. We can't use an
         # existing file since they are all unpredictably named.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -30,6 +30,7 @@ server 'app0.node.production', user: 'deploy', roles: %w{app}, port: 22
 server 'app1.node.production', user: 'deploy', roles: %w{app}, port: 22
 server 'asset.node.production', user: 'deploy', roles: %w{asset}, port: 22, :no_release => true
 server 'worker0.node.production', user: 'deploy', roles: %w{worker}, port: 22
+server 'osm-database.node.production', user: 'deploy', roles: %w{importer}, port: 22 # Used for replication.
 #server 'mysql.node.production', user: 'wheelmap', roles: %w{mysql}, port: 22
 
 # Custom SSH Options

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -25,6 +25,7 @@ server 'app0.node.staging', user: 'deploy', roles: %w{app}, port: 22
 server 'app1.node.staging', user: 'deploy', roles: %w{app}, port: 22
 server 'asset.node.staging', user: 'deploy', roles: %w{asset}, port: 22, :no_release => true
 server 'worker0.node.staging', user: 'deploy', roles: %w{worker}, port: 22
+server 'osm-database.node.staging', user: 'deploy', roles: %w{importer}, port: 22 # Used for replication.
 #server 'mysql.node.production', user: 'wheelmap', roles: %w{mysql}, port: 22
 
 # Custom SSH Options

--- a/lib/tasks/planet_reader.rake
+++ b/lib/tasks/planet_reader.rake
@@ -8,6 +8,7 @@ SHAPE_FILE = "#{VAR_DIR}/shapes.osc".freeze
 STATE_FILE = "#{WORKING_DIR}/state.txt".freeze
 BACKUP_FILE = "#{WORKING_DIR}/state.old".freeze
 DOWNLOAD_LOCK = "#{WORKING_DIR}/download.lock".freeze
+MAKE_OSC_DIR = "/var/apps/make_osc/".freeze
 
 require 'rake'
 
@@ -55,7 +56,7 @@ end
 
 def get_new_shape_replication_files
   puts "INFO: Fetching shape changes."
-  system "#{MAKE_OSC} -d >> #{SHAPE_FILE}"
+  system "BUNDLE_GEMFILE=#{MAKE_OSC_DIR}/Gemfile bundle exec #{MAKE_OSC_DIR}/make_osc.rb -d >> #{SHAPE_FILE}"
 end
 
 def merge_replication_files

--- a/lib/tasks/planet_reader.rake
+++ b/lib/tasks/planet_reader.rake
@@ -54,9 +54,8 @@ def get_new_replication_file
 end
 
 def get_new_shape_replication_files
-  puts 'INFO: Fetching shape changes.'
-  system "ssh -p 22022 osm@176.9.63.171 \"ruby make_osc.rb -d\" 2> /dev/null >> #{SHAPE_FILE}"
-  puts "INFO: Downloaded #{File.size(SHAPE_FILE)} bytes"
+  puts "INFO: Fetching shape changes."
+  system "#{MAKE_OSC} -d >> #{SHAPE_FILE}"
 end
 
 def merge_replication_files


### PR DESCRIPTION
There was an `make_osc.rb` and `string_hstore.rb` file on the deployed instances which was not in any of our repos. These are currently required for syncing between PostgreSQL and MySQL.

This PR converts configures things to appropriately talk to it.