### PR TITLE
Fix broken node_types api index action

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,3 +1,5 @@
+require 'float'
+
 class ActionController::UnpermittedValue < IndexError
   attr_reader :key, :value, :allowed_values
 

--- a/app/controllers/api/node_types_controller.rb
+++ b/app/controllers/api/node_types_controller.rb
@@ -1,7 +1,7 @@
 class Api::NodeTypesController < Api::ApiController
   defaults :resource_class => NodeType
 
-  belongs_to :category, :optional => true
+  belongs_to :category, :optional => true, :class_name => 'Category'
 
   actions :index, :show
 

--- a/spec/controllers/api/node_types_controller_spec.rb
+++ b/spec/controllers/api/node_types_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::NodeTypesController do
       @category = FactoryGirl.create(:category)
       education_category = FactoryGirl.create(:category, :identifier => 'education')
       @node_type = FactoryGirl.create(:node_type, :category => @category)
-      education_node_type = FactoryGirl.create(:node_type, :category => education_category)
+      FactoryGirl.create(:node_type, :category => education_category)
       @categories = Category.all
       expect(@categories).not_to be_empty
     end

--- a/spec/controllers/api/node_types_controller_spec.rb
+++ b/spec/controllers/api/node_types_controller_spec.rb
@@ -13,10 +13,24 @@ describe Api::NodeTypesController do
 
     before :each do
       @category = FactoryGirl.create(:category)
-      FactoryGirl.create(:category, :identifier => 'education')
+      education_category = FactoryGirl.create(:category, :identifier => 'education')
       @node_type = FactoryGirl.create(:node_type, :category => @category)
+      education_node_type = FactoryGirl.create(:node_type, :category => education_category)
       @categories = Category.all
       expect(@categories).not_to be_empty
+    end
+
+    it 'returns 200 status code' do
+      get(:index, category_id: @category.id, :api_key => @user.authentication_token)
+      expect(response.status).to eq 200
+    end
+
+    it 'returns node types for the specified category' do
+      get(:index, category_id: @category.id, :api_key => @user.authentication_token)
+      json_response = JSON.parse(response.body)
+      node_types = json_response['node_types']
+      category_ids = node_types.map { |node_type| node_type['category_id'] }
+      expect(category_ids.all?{ |category| category == @category.id }).to be true
     end
 
     describe 'format json' do


### PR DESCRIPTION
Resolves #148 

This fixes `'NoMethodError: undefined method find' for Api::Category:Module`

Apparently since inherited_resources 1.6 the automatic resolving of class names in `belongs_to` calls is broken. We work around this by defining the `class_name` explicitly.
See https://github.com/josevalim/inherited_resources/pull/407 for more details.