### PR TITLE
Fix/512 save both wheelchair and toilet

### DIFF
--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -446,7 +446,19 @@ describe Api::NodesController do
              :name => 'Cocktails on the rocks'}, :wheelchair => 'no', :api_key => @user.authentication_token})
         expect(response.status).to eql 202
       }.to change(Delayed::Job, :count).by(1)
+    end
 
+    it "creates node job with correct wheelchair attribute" do
+      @user.oauth_token = :a_token
+      @user.oauth_secret = :a_secret
+      @user.save!
+      expect(CreateNodeJob).to receive(:enqueue) do |_lat, _lng, tags, _current_user, _source|
+        expect(tags['wheelchair']).to eq 'yes'
+        expect(tags['toilets:wheelchair']).to eq 'yes'
+      end
+      request.headers['X-API-KEY'] = @user.authentication_token
+      post(:create, {"name"=>"centro cultural vergueiro", "type"=>"community_centre", "lat"=>"-23.5711773", "lon"=>"-46.6402144", "wheelchair"=>"yes", "wheelchair_toilet"=>"yes", "category"=>"leisure", "locale"=>"pt"})
+      expect(response.status).to eq 202
     end
 
     it "should compose source from user agent" do

--- a/spec/jobs/create_node_job_spec.rb
+++ b/spec/jobs/create_node_job_spec.rb
@@ -10,7 +10,7 @@ describe CreateNodeJob do
   let(:changeset) { Rosemary::Changeset.new(:id => 12345, :open? => true) }
 
   subject {
-    CreateNodeJob.enqueue(52.4, 13.0, { 'wheelchair' => 'yes', 'amenity' => 'bar', 'name' => 'White horse', 'operator' => 'Adolf Präg GmbH & Co. KG' }, user, 'create_iphone')
+    CreateNodeJob.enqueue(52.4, 13.0, { 'wheelchair' => 'yes', 'toilets:wheelchair' => 'yes', 'amenity' => 'bar', 'name' => 'White horse', 'operator' => 'Adolf Präg GmbH & Co. KG' }, user, 'create_iphone')
   }
 
   it "should create a Node" do
@@ -21,6 +21,7 @@ describe CreateNodeJob do
       expect(node.lat).to eql 52.4
       expect(node.lon).to eql 13.0
       expect(node.tags['wheelchair']).to eq 'yes'
+      expect(node.tags['toilets:wheelchair']).to eq 'yes'
       expect(node.tags['amenity']).to eq 'bar'
       expect(node.tags['name']).to eq 'White horse'
       expect(node.tags['operator']).to eq 'Adolf Präg GmbH &amp; Co. KG'

--- a/spec/models/poi_spec.rb
+++ b/spec/models/poi_spec.rb
@@ -131,6 +131,16 @@ describe Poi do
       p.send "wheelchair_toilet=", "yes"
       expect(p.tags["toilets:wheelchair"]).to eq("yes")
     end
+
+    it 'has wheelchair = no when passed via constructor' do
+      p = Poi.new("wheelchair" => "no")
+      expect(p.wheelchair).to eq("no")
+    end
+
+    it 'has wheelchair_toilet = no when passed via constructor' do
+      p = Poi.new("wheelchair_toilet" => "no")
+      expect(p.wheelchair_toilet).to eq("no")
+    end
   end
 
   context "json rendering" do


### PR DESCRIPTION
Related to #512 

This PR adds some tests to ensure that the API handles both `wheelchair` and `toilet:wheelchair` data correctly.

The tests in ` spec/models/poi_spec.rb` ensure that when `wheelchair` and `wheelchair_toilet` are set correctly on the model. I added these to make sure that the problem is not produced here.

The test in `spec/controllers/api/nodes_controller_spec.rb` tests the case that the API receives both `wheelchair` and `wheelchair_toilet` and passes that on to the job which then eventually makes the OSM API calls.

In `spec/jobs/create_node_job_spec.rb` we ensure that the job does not drop any of these data. 