### PR TITLE
Logging for planetreader create/delete

### DIFF
--- a/app/importer/planet_reader.rb
+++ b/app/importer/planet_reader.rb
@@ -78,7 +78,7 @@ class PlanetReader
     if @to_be_deleted.size >= min_amount
       Poi.where(:osm_id => @to_be_deleted).delete_all
       for deletion in @to_be_deleted do
-        puts "Deleting POI #{deletion[0]}"
+        puts "Deleting POI #{deletion}"
       end
       @to_be_deleted = []
     end

--- a/app/importer/planet_reader.rb
+++ b/app/importer/planet_reader.rb
@@ -67,6 +67,9 @@ class PlanetReader
   def create_pois(min_amount=500)
     if @to_be_created.size >= min_amount
       Poi.import @columns, @to_be_created, :validate => false, :on_duplicate_key_update => @columns_without_create, :timestamps => false
+      for creation in @to_be_created do
+        puts "Creating POI #{creation[0]}"
+      end
       @to_be_created = []
     end
   end
@@ -74,6 +77,9 @@ class PlanetReader
   def flush_pois(min_amount=500)
     if @to_be_deleted.size >= min_amount
       Poi.where(:osm_id => @to_be_deleted).delete_all
+      for deletion in @to_be_deleted do
+        puts "Deleting POI #{deletion[0]}"
+      end
       @to_be_deleted = []
     end
   end


### PR DESCRIPTION
Simple change to make the PlanetReader log OSM ids on create/delete.

Closes https://github.com/sozialhelden/wheelmap/issues/534.

Create output: 

```
Jan 12 14:33:43 osm-database bundle[25776]: Creating POI 249777139
Jan 12 14:33:43 osm-database bundle[25776]: Creating POI 251738707
```