### PR TITLE
This fixes a HTTP 500 error occured when trying to access /api/categories/:category_id/nodes

### DIFF
--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -5,7 +5,7 @@ class Api::NodesController < Api::ApiController
 
   custom_actions :collection => :search, :member => :update_wheelchair
 
-  optional_belongs_to :category
+  optional_belongs_to :category, :class_name => 'Category'
   optional_belongs_to :node_type
 
   # Make sure user authenticates itself using an api_key

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -13,7 +13,21 @@ describe Api::NodesController do
   describe 'index action' do
     before :each do
       Poi.delete_all
-      @nodes = [FactoryGirl.create(:poi, :osm_id => 1, :tags => {'wheelchair' => 'yes', 'name' => 'name', 'amenity' => 'bar'}), FactoryGirl.create(:poi, :osm_id => 2, :tags => {'wheelchair' => 'yes', 'name' => 'name', 'amenity' => 'bar'})]
+      @category = FactoryGirl.create(:category, :identifier => 'education')
+      @nodes = [
+        FactoryGirl.create(:poi, category: @category, :osm_id => 1, :tags => {'wheelchair' => 'yes', 'name' => 'name', 'amenity' => 'bar'}),
+        FactoryGirl.create(:poi, category: @category, :osm_id => 2, :tags => {'wheelchair' => 'yes', 'name' => 'name', 'amenity' => 'bar'}),
+      ]
+    end
+
+    describe 'get nodes for category' do
+      before do
+        get(:index, category_id: @category.id, :api_key => @user.authentication_token)
+      end
+
+      it 'returns 200 status code' do
+        expect(response.status).to eq 200
+      end
     end
 
     describe 'format json' do


### PR DESCRIPTION
This is related to #148 

It looks like after we've updated to inherited_resources 1.6 this piece also broke. We encountered the same error as in the referenced ticket. 

