### PR TITLE
Only outdoor views are shown.

### DIFF
--- a/app/assets/javascripts/nodes.coffee
+++ b/app/assets/javascripts/nodes.coffee
@@ -272,5 +272,5 @@ if $dropzoneClickable.length > 0
     heading = google.maps.geometry.spherical.computeHeading(data.location.latLng, position)
 
     streetView = new google.maps.StreetViewPanorama element,
-      position: position
+      pano: data.location.pano,
       pov: { heading: heading, pitch: 0 }


### PR DESCRIPTION
Referencing
https://code.google.com/p/gmaps-api-issues/issues/detail?id=4831 which
states that using the `pano` field corrects the issue.

## Example 1:

Before:
<img width="1326" alt="screen shot 2017-01-19 at 10 05 45" src="https://cloud.githubusercontent.com/assets/130903/22100388/c02a237e-de2f-11e6-84e7-ad6c8abafde3.png">

After:
<img width="1371" alt="screen shot 2017-01-19 at 10 05 15" src="https://cloud.githubusercontent.com/assets/130903/22100397/c4cf8536-de2f-11e6-834b-d1c78e6dccd7.png">

## Example 2

Before:
<img width="1377" alt="screen shot 2017-01-19 at 10 06 10" src="https://cloud.githubusercontent.com/assets/130903/22100404/cf2a3e7c-de2f-11e6-8097-ec2206a1d34f.png">

After:
<img width="1376" alt="screen shot 2017-01-19 at 10 05 02" src="https://cloud.githubusercontent.com/assets/130903/22100425/db853294-de2f-11e6-8a39-f7b54c53bcbe.png">


Fixes https://github.com/sozialhelden/wheelmap/issues/401.
