### PR TITLE
Fix/wrong toilet tag in changeset

### DIFF
--- a/lib/poi_migration.rb
+++ b/lib/poi_migration.rb
@@ -1,6 +1,12 @@
 module PoiMigration
+
   def self.convert(poi)
-    poi.tags["toilets:wheelchair"] = poi.tags["wheelchair_toilet"]
+    toilet = poi.toilet ? "yes" : "no"
+
+    if poi.tags["wheelchair_toilet"] == toilet && poi.tags["wheelchair_toilet"] != poi.tags["toilets:wheelchair"]
+      poi.tags["toilets:wheelchair"] = poi.tags["wheelchair_toilet"]
+    end
+
     poi.tags.delete("wheelchair_toilet")
     poi
   end

--- a/lib/poi_migration.rb
+++ b/lib/poi_migration.rb
@@ -1,5 +1,6 @@
 module PoiMigration
   def self.convert(poi)
+    poi.tags["toilets:wheelchair"] = poi.tags["wheelchair_toilet"]
     poi.tags.delete("wheelchair_toilet")
     poi
   end

--- a/lib/poi_migration.rb
+++ b/lib/poi_migration.rb
@@ -1,0 +1,6 @@
+module PoiMigration
+  def self.convert(poi)
+    poi.tags.delete("wheelchair_toilet")
+    poi
+  end
+end

--- a/lib/tasks/poi_migrator.rake
+++ b/lib/tasks/poi_migrator.rake
@@ -1,0 +1,17 @@
+require 'poi_migration'
+
+namespace :poi_migrator do
+	desc 'Migrate pois with invalid wheelchair_toilet tag'
+	task :run => :environment do
+		# Load pois from the database
+		pois = Poi.where("tags LIKE ?", '%wheelchair_toilet%')
+    puts "Loaded #{pois.count} pois with wheelchair_toilet tag"
+
+    # Loop through pois, migrate and save
+		pois.each do |poi|
+			poi_migrate = PoiMigration.convert(poi)
+			puts "Migrated Poi ID: #{poi.osm_id} - #{poi_migrate.tags}"
+			poi_migrate.save
+		end
+	end
+end

--- a/spec/lib/poi_migrator_spec.rb
+++ b/spec/lib/poi_migrator_spec.rb
@@ -12,5 +12,14 @@ describe "PoiMigration" do
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
     end
+
+    context "wheelchair_toilet has different value than toilet & toilets:wheelchair" do
+      let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "yes", "wheelchair_toilet" => "no"}, toilet: true) }
+
+      specify "wheelchair_toilet tag has been deleted" do
+        resulting_poi = PoiMigration.convert(poi)
+        expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/lib/poi_migrator_spec.rb
+++ b/spec/lib/poi_migrator_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'poi_migration'
+
+describe "PoiMigration" do
+
+  describe "migrates pois that are tagged as wheelchair_toilet" do
+    context "all toilet values are equal" do
+      let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "yes", "wheelchair_toilet" => "yes"}, toilet: true) }
+
+      specify "wheelchair_toilet tag has been deleted" do
+        resulting_poi = PoiMigration.convert(poi)
+        expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/lib/poi_migrator_spec.rb
+++ b/spec/lib/poi_migrator_spec.rb
@@ -21,5 +21,18 @@ describe "PoiMigration" do
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
     end
+  
+    context "toilets:wheelchair has different value than toilet & wheelchair_toilet" do
+      let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "no", "wheelchair_toilet" => "yes"}, toilet: true) }
+      subject(:resulting_poi) { PoiMigration.convert(poi) }
+
+      specify "wheelchair_toilet tag has been deleted" do
+        expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
+      end
+      
+      specify "toilets:wheelchair gets value from wheelchair_toilet" do
+        expect(resulting_poi.tags["toilets:wheelchair"]).to eq("yes")
+      end
+    end
   end
 end

--- a/spec/lib/poi_migrator_spec.rb
+++ b/spec/lib/poi_migrator_spec.rb
@@ -12,6 +12,14 @@ describe "PoiMigration" do
       specify "wheelchair_toilet tag has been deleted" do
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
+
+      specify "toilets:wheelchair keeps its value" do
+        expect(resulting_poi.tags["toilets:wheelchair"]).to eq("yes")
+      end
+
+      specify "toilet keeps its value" do
+        expect(resulting_poi.toilet).to be true
+      end
     end
 
     context "wheelchair_toilet has different value than toilet & toilets:wheelchair" do
@@ -20,6 +28,15 @@ describe "PoiMigration" do
       specify "wheelchair_toilet tag has been deleted" do
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
+
+      specify "toilets:wheelchair keeps its value" do
+        expect(resulting_poi.tags["toilets:wheelchair"]).to eq("yes")
+      end
+
+      specify "toilet keeps its value" do
+        expect(resulting_poi.toilet).to be true
+      end
+
     end
   
     context "toilets:wheelchair has different value than toilet & wheelchair_toilet" do

--- a/spec/lib/poi_migrator_spec.rb
+++ b/spec/lib/poi_migrator_spec.rb
@@ -4,11 +4,12 @@ require 'poi_migration'
 describe "PoiMigration" do
 
   describe "migrates pois that are tagged as wheelchair_toilet" do
+    subject(:resulting_poi) { PoiMigration.convert(poi) }
     context "all toilet values are equal" do
+
       let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "yes", "wheelchair_toilet" => "yes"}, toilet: true) }
 
       specify "wheelchair_toilet tag has been deleted" do
-        resulting_poi = PoiMigration.convert(poi)
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
     end
@@ -17,14 +18,12 @@ describe "PoiMigration" do
       let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "yes", "wheelchair_toilet" => "no"}, toilet: true) }
 
       specify "wheelchair_toilet tag has been deleted" do
-        resulting_poi = PoiMigration.convert(poi)
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)
       end
     end
   
     context "toilets:wheelchair has different value than toilet & wheelchair_toilet" do
       let(:poi) { FactoryGirl.build(:poi, tags: {"toilets:wheelchair" => "no", "wheelchair_toilet" => "yes"}, toilet: true) }
-      subject(:resulting_poi) { PoiMigration.convert(poi) }
 
       specify "wheelchair_toilet tag has been deleted" do
         expect(resulting_poi.tags["wheelchair_toilet"]).to eq(nil)


### PR DESCRIPTION
This PR migrates invalid `wheelchair_toilet` tags into `toilets:wheelchair` tags via a rake task. 

Fixes Github issue: https://github.com/sozialhelden/wheelmap/issues/400

Please don't merge yet, we are still waiting for @Svenyo's feedback how to progress. -> https://github.com/sozialhelden/wheelmap/issues/400#issuecomment-275070625