### PR TITLE
558 feat/node changes stream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :test do
   gem 'shoulda-matchers', '~> 3.1'
   gem 'syntax'
   gem 'email_spec'
+  gem 'json-schema', '~> 2.7'
 end
 
 group :production, :vagrant do

--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,7 @@ group :test do
   gem 'syntax'
   gem 'email_spec'
   gem 'json-schema', '~> 2.7'
+  gem 'timecop', '~> 0.8.1'
 end
 
 group :production, :vagrant do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    timecop (0.8.1)
     transaction-simple (1.4.0.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -643,6 +644,7 @@ DEPENDENCIES
   test-unit (~> 3.0)
   therubyracer
   thin
+  timecop (~> 0.8.1)
   uglifier
   unicorn
   useragent (~> 0.16.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,8 @@ GEM
       railties (>= 3.2)
       sprockets-rails
     json (1.8.3)
+    json-schema (2.7.0)
+      addressable (>= 2.4)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -599,6 +601,7 @@ DEPENDENCIES
   inherited_resources (~> 1.6.0)
   jquery-rails (= 2.3.0)
   js-routes
+  json-schema (~> 2.7)
   kaminari (~> 0.14)
   kaminari-i18n
   launchy

--- a/app/assets/javascripts/controllers/map.controller.js.coffee
+++ b/app/assets/javascripts/controllers/map.controller.js.coffee
@@ -6,7 +6,7 @@ Wheelmap.MapSessionControllerMixin = Ember.Mixin.create
   latBinding: 'controllers.map.lat'
   lonBinding: 'controllers.map.lon'
   zoomBinding: 'controllers.map.zoom'
-  qBinding: 'controllers.toolbar.searchString'
+  qBinding: 'controllers.toolbar.queryString'
   bbox: null
   debugBinding: 'controllers.map.debug'
   nodeIdBinding: 'controllers.map.nodeId'

--- a/app/assets/javascripts/controllers/toolbar.controller.js.coffee
+++ b/app/assets/javascripts/controllers/toolbar.controller.js.coffee
@@ -5,7 +5,7 @@ Wheelmap.ToolbarController = Ember.ArrayController.extend
 
   statusFilters: null
   toiletFilters: null
-  searchString: null
+  queryString: null
   itemController: 'category'
   sortProperties: ['name']
 
@@ -43,6 +43,10 @@ Wheelmap.ToolbarController = Ember.ArrayController.extend
 
     @filterBy('isActive')
   ).property('@each.isActive')
+
+  searchString: Ember.computed('queryString', ->
+    return decodeURIComponent(this.get('queryString').replace(/\+/g, ' '))
+  )
 
   activeStatusFilters: ((key, activeStatusFilters)->
     statusFilters = @get('statusFilters')

--- a/app/assets/javascripts/controllers/toolbar.controller.js.coffee
+++ b/app/assets/javascripts/controllers/toolbar.controller.js.coffee
@@ -45,7 +45,11 @@ Wheelmap.ToolbarController = Ember.ArrayController.extend
   ).property('@each.isActive')
 
   searchString: Ember.computed('queryString', ->
-    return decodeURIComponent(this.get('queryString').replace(/\+/g, ' '))
+    queryString = this.get('queryString')
+    if queryString?
+      return decodeURIComponent(queryString.replace(/\+/g, ' '))
+    else
+      return queryString
   )
 
   activeStatusFilters: ((key, activeStatusFilters)->

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -195,9 +195,15 @@ class Api::NodesController < Api::ApiController
   param :since, Date, :required => true, :desc => "Specifies start date"
   def changes
     timestamp = params[:since]
-    pois = Poi.where('updated_at >= ?', timestamp)
-    respond_to do |format|
-      format.json { render_for_api :changes_stream, :json => pois, :status => 200 }
+    if timestamp.nil?
+      respond_to do |format|
+        format.json { render :json => { :error => "Parameter 'since' required" }.to_json, :status => 400 }
+      end
+    else
+      pois = Poi.where('updated_at >= ?', timestamp)
+      respond_to do |format|
+        format.json { render_for_api :changes_stream, :json => pois, :status => 200 }
+      end
     end
   end
 

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -204,6 +204,8 @@ class Api::NodesController < Api::ApiController
       deleted_pois = PoiLog.where('created_at >= ?', timestamp)
       pois = (updated_pois + deleted_pois).to_a.sort { |a,b| a.updated_at <=> b.updated_at }
       respond_to do |format|
+        # We pass `:root => :pois` explicitly here because in case of an empty list
+        # apparently acts_as_api is not able to figure out the desired value for the root element (which is `pois`) and defaults to `records`.
         format.json { render_for_api :changes_stream, :json => pois, :root => :pois, :status => 200 }
       end
     end

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -192,7 +192,8 @@ class Api::NodesController < Api::ApiController
   end
 
   def changes
-    pois = Poi.take(20)
+    timestamp = params[:since]
+    pois = Poi.where('updated_at >= ?', timestamp)
     respond_to do |format|
       format.json { render_for_api :changes_stream, :json => pois, :status => 200 }
     end

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -191,6 +191,12 @@ class Api::NodesController < Api::ApiController
     end
   end
 
+  def changes
+    respond_to do |wants|
+      wants.json{ render :json => {:message => 'OK'}.to_json, :status => 200 }
+    end
+  end
+
   protected
 
   def collection

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -200,9 +200,11 @@ class Api::NodesController < Api::ApiController
         format.json { render :json => { :error => "Parameter 'since' required" }.to_json, :status => 400 }
       end
     else
-      pois = Poi.where('updated_at >= ?', timestamp)
+      updated_pois = Poi.where('updated_at >= ?', timestamp)
+      deleted_pois = PoiLog.where('created_at >= ?', timestamp)
+      pois = (updated_pois + deleted_pois).to_a.sort { |a,b| a.updated_at <=> b.updated_at }
       respond_to do |format|
-        format.json { render_for_api :changes_stream, :json => pois, :status => 200 }
+        format.json { render_for_api :changes_stream, :json => pois, :root => :pois, :status => 200 }
       end
     end
   end

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -191,6 +191,8 @@ class Api::NodesController < Api::ApiController
     end
   end
 
+  api :GET, "/nodes/changes", "Get node changes stream"
+  param :since, Date, :required => true, :desc => "Specifies start date"
   def changes
     timestamp = params[:since]
     pois = Poi.where('updated_at >= ?', timestamp)

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -192,8 +192,9 @@ class Api::NodesController < Api::ApiController
   end
 
   def changes
-    respond_to do |wants|
-      wants.json{ render :json => {:message => 'OK'}.to_json, :status => 200 }
+    pois = Poi.take(20)
+    respond_to do |format|
+      format.json { render_for_api :changes_stream, :json => pois, :status => 200 }
     end
   end
 

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -200,9 +200,7 @@ class Api::NodesController < Api::ApiController
         format.json { render :json => { :error => "Parameter 'since' required" }.to_json, :status => 400 }
       end
     else
-      updated_pois = Poi.where('updated_at >= ?', timestamp)
-      deleted_pois = PoiLog.where('created_at >= ?', timestamp)
-      pois = (updated_pois + deleted_pois).to_a.sort { |a,b| a.updated_at <=> b.updated_at }
+      pois = PoiLog.where('created_at >= ?', timestamp)
       respond_to do |format|
         # We pass `:root => :pois` explicitly here because in case of an empty list
         # apparently acts_as_api is not able to figure out the desired value for the root element (which is `pois`) and defaults to `records`.

--- a/app/importer/planet_reader.rb
+++ b/app/importer/planet_reader.rb
@@ -264,4 +264,3 @@ class PlanetReader
     end
   end
 end
-

--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -62,6 +62,7 @@ class Poi < ActiveRecord::Base
   before_save :set_version
   before_save :set_updated_at
   after_destroy :log_poi_destroy
+  after_update :log_poi_update
 
   # Spezielle Find-Methode fuer den Zugriff auf alle POIs in einer
   # Bounding-Box. Fruehere Versionen von GeoRuby hatten dazu etwas
@@ -535,6 +536,10 @@ class Poi < ActiveRecord::Base
 
   def log_poi_destroy
     PoiLogger.log_delete(self)
+  end
+
+  def log_poi_update
+    PoiLogger.log_update(self)
   end
 
 end

--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -61,6 +61,7 @@ class Poi < ActiveRecord::Base
   before_save :set_status
   before_save :set_version
   before_save :set_updated_at
+  after_destroy :log_poi_destroy
 
   # Spezielle Find-Methode fuer den Zugriff auf alle POIs in einer
   # Bounding-Box. Fruehere Versionen von GeoRuby hatten dazu etwas
@@ -528,6 +529,12 @@ class Poi < ActiveRecord::Base
   # Dummy methods to generate full image paths
   def controller
     ''
+  end
+
+  private
+
+  def log_poi_destroy
+    PoiLogger.log_delete(self)
   end
 
 end

--- a/app/models/poi_log.rb
+++ b/app/models/poi_log.rb
@@ -1,0 +1,3 @@
+class PoiLog < ActiveRecord::Base
+	
+end

--- a/app/models/poi_log.rb
+++ b/app/models/poi_log.rb
@@ -1,3 +1,4 @@
 class PoiLog < ActiveRecord::Base
-	
+	acts_as_api
+	include Api::PoiLog
 end

--- a/app/models/poi_logger.rb
+++ b/app/models/poi_logger.rb
@@ -1,5 +1,9 @@
 class PoiLogger
   def self.log_delete(poi)
-    PoiLog.create(osm_id: poi.osm_id)
+    PoiLog.create(osm_id: poi.osm_id, action: "delete")
+  end
+
+  def self.log_update(poi)
+    PoiLog.create(osm_id: poi.osm_id, action: "update")
   end
 end

--- a/app/models/poi_logger.rb
+++ b/app/models/poi_logger.rb
@@ -1,0 +1,5 @@
+class PoiLogger
+  def self.log_delete(poi)
+    PoiLog.create(osm_id: poi.osm_id)
+  end
+end

--- a/app/representations/api/poi.rb
+++ b/app/representations/api/poi.rb
@@ -10,6 +10,12 @@ module Api::Poi
       end
     end
 
+    api_accessible :changes_stream do |t|
+      t.add :osm_id
+      # t.add :action
+      # t.add :timestamp
+    end
+
     # Please do not edit, this is the current stable API JSON representation!!!
     api_accessible :simple do |t|
       t.add :name

--- a/app/representations/api/poi.rb
+++ b/app/representations/api/poi.rb
@@ -10,17 +10,6 @@ module Api::Poi
       end
     end
 
-    # API template for '/nodes/changes'
-    api_accessible :changes_stream do |t|
-      t.add :osm_id
-      t.add :action
-      t.add lambda { |poi| poi.updated_at }, :as => :timestamp
-    end
-
-    def action
-      "update"
-    end
-
     # Please do not edit, this is the current stable API JSON representation!!!
     api_accessible :simple do |t|
       t.add :name

--- a/app/representations/api/poi.rb
+++ b/app/representations/api/poi.rb
@@ -10,10 +10,15 @@ module Api::Poi
       end
     end
 
+    # API template for '/nodes/changes'
     api_accessible :changes_stream do |t|
       t.add :osm_id
-      # t.add :action
-      # t.add :timestamp
+      t.add :action
+      t.add lambda { |poi| poi.updated_at }, :as => :timestamp
+    end
+
+    def action
+      "update"
     end
 
     # Please do not edit, this is the current stable API JSON representation!!!

--- a/app/representations/api/poi_log.rb
+++ b/app/representations/api/poi_log.rb
@@ -15,9 +15,5 @@ module Api::PoiLog
       t.add :action
       t.add lambda { |poi| poi.created_at }, :as => :timestamp
     end
-
-    def action
-      "delete"
-    end
 	end
 end

--- a/app/representations/api/poi_log.rb
+++ b/app/representations/api/poi_log.rb
@@ -1,0 +1,23 @@
+module Api::PoiLog
+  extend ActiveSupport::Concern
+
+  included do
+		def around_api_response(api_template)
+			custom_cache_key = "api_response_#{I18n.locale}_#{self.cache_key}_#{api_template.to_s}"
+			Rails.cache.fetch(custom_cache_key, :expires_in => 1.hour) do
+				yield
+			end
+		end
+
+		# API template for '/nodes/changes'
+    api_accessible :changes_stream do |t|
+      t.add :osm_id
+      t.add :action
+      t.add lambda { |poi| poi.created_at }, :as => :timestamp
+    end
+
+    def action
+      "delete"
+    end
+	end
+end

--- a/app/representations/api/poi_log.rb
+++ b/app/representations/api/poi_log.rb
@@ -2,18 +2,11 @@ module Api::PoiLog
   extend ActiveSupport::Concern
 
   included do
-		def around_api_response(api_template)
-			custom_cache_key = "api_response_#{I18n.locale}_#{self.cache_key}_#{api_template.to_s}"
-			Rails.cache.fetch(custom_cache_key, :expires_in => 1.hour) do
-				yield
-			end
-		end
-
-		# API template for '/nodes/changes'
+    # API template for '/nodes/changes'
     api_accessible :changes_stream do |t|
       t.add :osm_id
       t.add :action
       t.add lambda { |poi| poi.created_at }, :as => :timestamp
     end
-	end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Wheelmap::Application.routes.draw do
       collection do
         get :search
         get :counts, :to => 'counter#index'
+        get :changes
       end
       member do
         put :update_wheelchair

--- a/db/migrate/20170202152914_create_poi_logs.rb
+++ b/db/migrate/20170202152914_create_poi_logs.rb
@@ -1,0 +1,9 @@
+class CreatePoiLogs < ActiveRecord::Migration
+  def change
+    create_table :poi_logs do |t|
+      t.integer :osm_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170206150119_add_action_to_poi_logs.rb
+++ b/db/migrate/20170206150119_add_action_to_poi_logs.rb
@@ -1,0 +1,5 @@
+class AddActionToPoiLogs < ActiveRecord::Migration
+  def change
+    add_column :poi_logs, :action, :string, default: ""
+  end
+end

--- a/db/migrate/20170207133358_change_osm_id_column_type_to_big_int_in_poi_logs.rb
+++ b/db/migrate/20170207133358_change_osm_id_column_type_to_big_int_in_poi_logs.rb
@@ -1,0 +1,5 @@
+class ChangeOsmIdColumnTypeToBigIntInPoiLogs < ActiveRecord::Migration
+  def change
+    change_column :poi_logs, :osm_id, :integer, limit: 8
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,6 @@
 -- MySQL dump 10.13  Distrib 5.6.16, for debian-linux-gnu (x86_64)
 --
--- Host: localhost    Database: wheelmap_test
+-- Host: localhost    Database: wheelmap_development
 -- ------------------------------------------------------
 -- Server version	5.6.16-1~exp1
 
@@ -126,7 +126,7 @@ CREATE TABLE `categories` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=85 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -157,7 +157,7 @@ CREATE TABLE `counters` (
   `toilet_iphone` int(11) DEFAULT '0',
   `toilet_android` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -205,7 +205,7 @@ CREATE TABLE `delayed_jobs` (
   `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -224,7 +224,7 @@ CREATE TABLE `iphone_counters` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -267,7 +267,7 @@ CREATE TABLE `node_types` (
   PRIMARY KEY (`id`),
   KEY `index_node_types_on_id_and_category_id` (`id`,`category_id`),
   KEY `index_node_types_on_osm_key_and_osm_value` (`osm_key`,`osm_value`)
-) ENGINE=InnoDB AUTO_INCREMENT=1072464140 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=172 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -320,12 +320,12 @@ DROP TABLE IF EXISTS `poi_logs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poi_logs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `osm_id` int(11) DEFAULT NULL,
+  `osm_id` bigint(20) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `action` varchar(255) DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -449,7 +449,7 @@ CREATE TABLE `regions` (
   `slug` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_regions_on_slug` (`slug`)
-) ENGINE=InnoDB AUTO_INCREMENT=73 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -550,7 +550,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_authentication_token` (`authentication_token`),
   KEY `index_users_on_oauth_token` (`oauth_token`),
   KEY `index_users_on_wants_newsletter` (`wants_newsletter`)
-) ENGINE=InnoDB AUTO_INCREMENT=120 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -585,7 +585,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-06 15:05:14
+-- Dump completed on 2017-02-07 13:45:26
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -737,4 +737,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161128102235');
 INSERT INTO schema_migrations (version) VALUES ('20170202152914');
 
 INSERT INTO schema_migrations (version) VALUES ('20170206150119');
+
+INSERT INTO schema_migrations (version) VALUES ('20170207133358');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,7 @@ CREATE TABLE `categories` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=275 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=85 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -157,7 +157,7 @@ CREATE TABLE `counters` (
   `toilet_iphone` int(11) DEFAULT '0',
   `toilet_android` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -177,7 +177,7 @@ CREATE TABLE `datapoints` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_datapoints_on_measurement_id` (`measurement_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=55 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -205,7 +205,7 @@ CREATE TABLE `delayed_jobs` (
   `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=33 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -243,7 +243,7 @@ CREATE TABLE `measurements` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_measurements_on_photo_id` (`photo_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -267,7 +267,7 @@ CREATE TABLE `node_types` (
   PRIMARY KEY (`id`),
   KEY `index_node_types_on_id_and_category_id` (`id`,`category_id`),
   KEY `index_node_types_on_osm_key_and_osm_value` (`osm_key`,`osm_value`)
-) ENGINE=InnoDB AUTO_INCREMENT=1072464206 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1072464140 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -308,7 +308,7 @@ CREATE TABLE `photos` (
   `image_gallery_preview_width` int(11) DEFAULT NULL,
   `image_gallery_preview_height` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -323,8 +323,9 @@ CREATE TABLE `poi_logs` (
   `osm_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
+  `action` varchar(255) DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -375,7 +376,7 @@ CREATE TABLE `provided_pois` (
   `wheelchair_toilet` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_provided_pois_on_provider_id_and_poi_id` (`provider_id`,`poi_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -392,7 +393,7 @@ CREATE TABLE `providers` (
   `updated_at` datetime DEFAULT NULL,
   `logo` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -448,7 +449,7 @@ CREATE TABLE `regions` (
   `slug` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_regions_on_slug` (`slug`)
-) ENGINE=InnoDB AUTO_INCREMENT=220 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=73 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -549,7 +550,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_authentication_token` (`authentication_token`),
   KEY `index_users_on_oauth_token` (`oauth_token`),
   KEY `index_users_on_wants_newsletter` (`wants_newsletter`)
-) ENGINE=InnoDB AUTO_INCREMENT=271 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=120 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -572,7 +573,7 @@ CREATE TABLE `widgets` (
   `south_east` point DEFAULT NULL,
   `north_west` point DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -584,7 +585,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-03 14:07:11
+-- Dump completed on 2017-02-06 15:05:14
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -734,4 +735,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161021141630');
 INSERT INTO schema_migrations (version) VALUES ('20161128102235');
 
 INSERT INTO schema_migrations (version) VALUES ('20170202152914');
+
+INSERT INTO schema_migrations (version) VALUES ('20170206150119');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,7 @@ CREATE TABLE `categories` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=240 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=275 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -157,7 +157,7 @@ CREATE TABLE `counters` (
   `toilet_iphone` int(11) DEFAULT '0',
   `toilet_android` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -177,7 +177,7 @@ CREATE TABLE `datapoints` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_datapoints_on_measurement_id` (`measurement_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=55 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -205,7 +205,7 @@ CREATE TABLE `delayed_jobs` (
   `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=33 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -224,7 +224,7 @@ CREATE TABLE `iphone_counters` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -243,7 +243,7 @@ CREATE TABLE `measurements` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_measurements_on_photo_id` (`photo_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -267,7 +267,7 @@ CREATE TABLE `node_types` (
   PRIMARY KEY (`id`),
   KEY `index_node_types_on_id_and_category_id` (`id`,`category_id`),
   KEY `index_node_types_on_osm_key_and_osm_value` (`osm_key`,`osm_value`)
-) ENGINE=InnoDB AUTO_INCREMENT=1072464284 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1072464206 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -308,7 +308,23 @@ CREATE TABLE `photos` (
   `image_gallery_preview_width` int(11) DEFAULT NULL,
   `image_gallery_preview_height` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `poi_logs`
+--
+
+DROP TABLE IF EXISTS `poi_logs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `poi_logs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `osm_id` int(11) DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -359,7 +375,7 @@ CREATE TABLE `provided_pois` (
   `wheelchair_toilet` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_provided_pois_on_provider_id_and_poi_id` (`provider_id`,`poi_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -376,7 +392,7 @@ CREATE TABLE `providers` (
   `updated_at` datetime DEFAULT NULL,
   `logo` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -432,7 +448,7 @@ CREATE TABLE `regions` (
   `slug` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_regions_on_slug` (`slug`)
-) ENGINE=InnoDB AUTO_INCREMENT=93 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=220 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -533,7 +549,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_authentication_token` (`authentication_token`),
   KEY `index_users_on_oauth_token` (`oauth_token`),
   KEY `index_users_on_wants_newsletter` (`wants_newsletter`)
-) ENGINE=InnoDB AUTO_INCREMENT=53 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=271 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -556,7 +572,7 @@ CREATE TABLE `widgets` (
   `south_east` point DEFAULT NULL,
   `north_west` point DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -568,7 +584,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-12-13  9:54:15
+-- Dump completed on 2017-02-03 14:07:11
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -716,4 +732,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161017135542');
 INSERT INTO schema_migrations (version) VALUES ('20161021141630');
 
 INSERT INTO schema_migrations (version) VALUES ('20161128102235');
+
+INSERT INTO schema_migrations (version) VALUES ('20170202152914');
 

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -555,14 +555,15 @@ describe Api::NodesController do
             expect(validate_schema("spec/schema/node_stream.json", json_response)).to be true
           end
 
-          it "contains five entries" do
-            expect(json_response["pois"].length).to eq(5)
+          it "contains five updated entries" do
+            expect(json_response["pois"].count { |poi| poi["action"] == "update"}).to eq(5)
           end
 
           it "contains node changes according to the given date" do
             timestamps = json_response["pois"].map { |poi| DateTime.parse(poi["timestamp"]) }
             expect(timestamps.all? { |timestamp| timestamp >= date_today.to_date }).to be true
           end
+
         end
       end
 
@@ -574,7 +575,7 @@ describe Api::NodesController do
           get(:changes, { since: (Date.today + 7.days).to_s, api_key: @user.authentication_token })
         end
 
-        it "result in an empty list" do
+        it "results in an empty list" do
           expect(json_response["pois"]).to be_empty
         end
       end

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -560,12 +560,13 @@ describe Api::NodesController do
 
       before :all do
         Poi.delete_all
+        PoiLog.delete_all
         Timecop.travel(date_yesterday)
-        create_list(:poi, 5)
-        create_list(:poi_log, 5)
+        create_list(:poi_log, 5, action: "update")
+        create_list(:poi_log, 5, action: "delete")
         Timecop.travel(date_today)
-        create_list(:poi, 5)
-        create_list(:poi_log, 5)
+        create_list(:poi_log, 5, action: "update")
+        create_list(:poi_log, 5, action: "delete")
         Timecop.return
       end
 

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -504,4 +504,17 @@ describe Api::NodesController do
       }.to change(Delayed::Job, :count).by(1)
     end
   end
+
+  describe 'changes stream' do
+    before do
+      @user.oauth_token = :a_token
+      @user.oauth_secret = :a_secret
+      @user.save!
+      get(:changes, { :api_key => @user.authentication_token })
+    end
+
+    it "returns 200 status code" do
+      expect(response.status).to eq(200)
+    end
+  end
 end

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -578,6 +578,23 @@ describe Api::NodesController do
           expect(json_response["pois"]).to be_empty
         end
       end
+
+      context 'without a date' do
+        before do
+          @user.oauth_token = :a_token
+          @user.oauth_secret = :a_secret
+          @user.save!
+          get(:changes, { api_key: @user.authentication_token })
+        end
+
+        it "returns 400 status code" do
+          expect(response.status).to eq 400
+        end
+
+        it "returns error message" do
+          expect(json_response["error"].length).to be > 0
+        end
+      end
     end
 
     context 'without API key' do

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -529,8 +529,10 @@ describe Api::NodesController do
         Poi.delete_all
         Timecop.travel(date_yesterday)
         create_list(:poi, 5)
+        create_list(:poi_log, 5)
         Timecop.travel(date_today)
         create_list(:poi, 5)
+        create_list(:poi_log, 5)
         Timecop.return
       end
 
@@ -557,6 +559,10 @@ describe Api::NodesController do
 
           it "contains five updated entries" do
             expect(json_response["pois"].count { |poi| poi["action"] == "update"}).to eq(5)
+          end
+
+          it "contains five deleted entries" do
+            expect(json_response["pois"].count { |poi| poi["action"] == "delete"}).to eq(5)
           end
 
           it "contains node changes according to the given date" do

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -506,16 +506,32 @@ describe Api::NodesController do
   end
 
   describe 'changes stream' do
+    def json_response
+      JSON.parse(response.body)
+    end
+
     context 'with API key' do
       before do
         @user.oauth_token = :a_token
         @user.oauth_secret = :a_secret
         @user.save!
+        create_list(:poi, 20, created_at: DateTime.now, updated_at: DateTime.now)
+        create_list(:poi, 5, created_at: 1.day.ago, updated_at: 1.day.ago)
         get(:changes, { :api_key => @user.authentication_token })
       end
 
       it "returns 200 status code" do
         expect(response.status).to eq(200)
+      end
+
+      it "returns response format to be json" do
+        expect(response.headers["Content-Type"]).to eql("application/json; charset=utf-8")
+      end
+
+      context "the JSON response" do
+        it "contains twenty entries" do
+          expect(json_response["pois"].length).to eq(20)
+        end
       end
     end
 

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -535,15 +535,15 @@ describe Api::NodesController do
         expect(response.status).to eq(200)
       end
 
-      it "returns response format to be json" do
-        expect(response.headers["Content-Type"]).to eql("application/json; charset=utf-8")
-      end
-
-      it "validates against node stream schema" do
-        expect(validate_schema("spec/schema/node_stream.json", json_response)).to be true
-      end
-
       context "the JSON response" do
+        it "has correct content-type" do
+          expect(response.headers["Content-Type"]).to eql("application/json; charset=utf-8")
+        end
+
+        it "validates against node stream schema" do
+          expect(validate_schema("spec/schema/node_stream.json", json_response)).to be true
+        end
+
         it "contains twenty entries" do
           expect(json_response["pois"].length).to eq(20)
         end

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'json-schema'
 
 describe Api::NodesController do
 
@@ -522,15 +521,35 @@ describe Api::NodesController do
     end
 
     context 'poi logger' do
+      let(:poi) { create(:poi) }
+      let(:log_entry) { PoiLog.last }
+
       context 'for deleted pois' do
-        let(:poi) { create(:poi) }
         before do
           poi.destroy
         end
 
         it 'creates a new log entry for the deleted poi' do
-          log_entry = PoiLog.last
           expect(log_entry.osm_id).to eq poi.osm_id
+        end
+
+        it 'creates a new log entry with action = deleted' do
+          expect(log_entry.action).to eq('delete')
+        end
+      end
+
+      context 'for updated pois' do
+        before do
+          poi.wheelchair = 'yes'
+          poi.save
+        end
+
+        it 'creates a new log entry for the updated poi' do
+          expect(log_entry.osm_id).to eq poi.osm_id
+        end
+
+        it 'creates a new log entry with action = updated' do
+          expect(log_entry.action).to eq('update')
         end
       end
     end

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -521,6 +521,20 @@ describe Api::NodesController do
       JSON.parse(response.body)
     end
 
+    context 'poi logger' do
+      context 'for deleted pois' do
+        let(:poi) { create(:poi) }
+        before do
+          poi.destroy
+        end
+
+        it 'creates a new log entry for the deleted poi' do
+          log_entry = PoiLog.last
+          expect(log_entry.osm_id).to eq poi.osm_id
+        end
+      end
+    end
+
     context 'with API key' do
       date_today = DateTime.new(2016,2,1,20,0,0)
       date_yesterday = DateTime.new(2016,1,31,20,0,0)
@@ -569,7 +583,6 @@ describe Api::NodesController do
             timestamps = json_response["pois"].map { |poi| DateTime.parse(poi["timestamp"]) }
             expect(timestamps.all? { |timestamp| timestamp >= date_today.to_date }).to be true
           end
-
         end
       end
 

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -506,15 +506,27 @@ describe Api::NodesController do
   end
 
   describe 'changes stream' do
-    before do
-      @user.oauth_token = :a_token
-      @user.oauth_secret = :a_secret
-      @user.save!
-      get(:changes, { :api_key => @user.authentication_token })
+    context 'with API key' do
+      before do
+        @user.oauth_token = :a_token
+        @user.oauth_secret = :a_secret
+        @user.save!
+        get(:changes, { :api_key => @user.authentication_token })
+      end
+
+      it "returns 200 status code" do
+        expect(response.status).to eq(200)
+      end
     end
 
-    it "returns 200 status code" do
-      expect(response.status).to eq(200)
+    context 'without API key' do
+      before do
+        get(:changes)
+      end
+
+      it "returns 401 status code" do
+        expect(response.status).to eq(401)
+      end
     end
   end
 end

--- a/spec/controllers/api/nodes_controller_spec.rb
+++ b/spec/controllers/api/nodes_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'json-schema'
 
 describe Api::NodesController do
 
@@ -506,6 +507,16 @@ describe Api::NodesController do
   end
 
   describe 'changes stream' do
+    def validate_schema(schema_file, json)
+      schema = JSON.parse(File.read(schema_file))
+      errors = JSON::Validator.fully_validate(schema, json)
+
+      return true if errors.empty?
+
+      errors.each { |error| STDOUT.puts error }
+      false
+    end
+
     def json_response
       JSON.parse(response.body)
     end
@@ -526,6 +537,10 @@ describe Api::NodesController do
 
       it "returns response format to be json" do
         expect(response.headers["Content-Type"]).to eql("application/json; charset=utf-8")
+      end
+
+      it "validates against node stream schema" do
+        expect(validate_schema("spec/schema/node_stream.json", json_response)).to be true
       end
 
       context "the JSON response" do

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -18,7 +18,7 @@ describe CategoriesController do
 
     describe 'the response' do
       it 'has categories' do
-        expect(json_response['categories'].length).to eq 1
+        expect(json_response['categories'].length).to be > 0
       end
     end
   end

--- a/spec/factories/poi_log_factory.rb
+++ b/spec/factories/poi_log_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+
+	factory :poi_log do
+		osm_id {FactoryGirl.generate :version}
+	end
+end

--- a/spec/models/poi_log_spec.rb
+++ b/spec/models/poi_log_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PoiLog, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/schema/node_stream.json
+++ b/spec/schema/node_stream.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Node Stream Response Schema",
+  "type": "object",
+  "required": ["pois"],
+  "properties": {
+    "pois": {
+      "type": "array",
+      "items": [
+        { "$ref": "#/definitions/node" }
+      ]
+    }
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "required": ["osm_id", "action", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "osm_id": {
+          "type": "integer"
+        },
+        "action": {
+          "enum": ["update", "delete"]
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new API endpoint for node changes, updated and deleted nodes. The client can specify the start date to search for. 

**Based on following cases:**
  - return a response if the poi has been changed
  - return a response if the poi has been deleted (not existent)
  - return  an empty response if  the date is in the future (not existent)
  - return an error response when no date has been submitted

**we implemented the task as follows:**
- we added another table in the database to log via callbacks as soon as a poi has been changed or deleted


Resolves Github ticket #558. 