### PR TITLE
Forbid anonymous users to create and update nodes

### DIFF
--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -10,6 +10,8 @@ class Api::NodesController < Api::ApiController
 
   # Make sure user authenticates itself using an api_key
   before_filter :authenticate_application!, :only => [:update, :create]
+  # A user cannot be anonymous if they want to create or update a node
+  before_filter :ensure_not_anonymous!, :only => [:create, :update]
 
   has_scope :bbox, :except => :search # we handle this manually
   has_scope :wheelchair, :except => :update
@@ -269,4 +271,12 @@ class Api::NodesController < Api::ApiController
     end
   end
 
+  def ensure_not_anonymous!
+    if current_user.anonymous?
+      respond_to do |format|
+        format.json { render :json => {:message => 'Cannot use anonymous user'}.to_json, :status => 403 }
+        format.xml  { render :xml  => {:message => 'Cannot use anonymous user'}.to_xml,  :status => 403 }
+      end
+    end
+  end
 end

--- a/db/migrate/20170209093420_add_anonymous_flag_to_users.rb
+++ b/db/migrate/20170209093420_add_anonymous_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddAnonymousFlagToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :anonymous, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20170217131434_change_anonymous_flag_for_wheelmap_visitor_and_wheelmap_android.rb
+++ b/db/migrate/20170217131434_change_anonymous_flag_for_wheelmap_visitor_and_wheelmap_android.rb
@@ -1,0 +1,23 @@
+class ChangeAnonymousFlagForWheelmapVisitorAndWheelmapAndroid < ActiveRecord::Migration
+
+  EMAILS = [ 'visitor@wheelmap.org', 'android_app@wheelmap.org']
+
+  def up
+    change_anonymous_flag(true)
+  end
+
+  def down
+    change_anonymous_flag(false)
+  end
+
+  private
+  
+  def change_anonymous_flag(anonymous_flag)
+    users = User.where(email: EMAILS)
+
+    users.each do |user|
+      user.anonymous = anonymous_flag
+      user.save!
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,6 @@
 -- MySQL dump 10.13  Distrib 5.6.16, for debian-linux-gnu (x86_64)
 --
--- Host: localhost    Database: wheelmap_development
+-- Host: localhost    Database: wheelmap_test
 -- ------------------------------------------------------
 -- Server version	5.6.16-1~exp1
 
@@ -126,7 +126,7 @@ CREATE TABLE `categories` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=75 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -157,7 +157,7 @@ CREATE TABLE `counters` (
   `toilet_iphone` int(11) DEFAULT '0',
   `toilet_android` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -205,7 +205,7 @@ CREATE TABLE `delayed_jobs` (
   `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -224,7 +224,7 @@ CREATE TABLE `iphone_counters` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -267,7 +267,7 @@ CREATE TABLE `node_types` (
   PRIMARY KEY (`id`),
   KEY `index_node_types_on_id_and_category_id` (`id`,`category_id`),
   KEY `index_node_types_on_osm_key_and_osm_value` (`osm_key`,`osm_value`)
-) ENGINE=InnoDB AUTO_INCREMENT=172 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1072464130 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -323,9 +323,9 @@ CREATE TABLE `poi_logs` (
   `osm_id` bigint(20) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `action` varchar(255) DEFAULT '',
+  `action` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -449,7 +449,7 @@ CREATE TABLE `regions` (
   `slug` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_regions_on_slug` (`slug`)
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=63 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -551,7 +551,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_authentication_token` (`authentication_token`),
   KEY `index_users_on_oauth_token` (`oauth_token`),
   KEY `index_users_on_wants_newsletter` (`wants_newsletter`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=121 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -586,7 +586,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-09  9:44:30
+-- Dump completed on 2017-02-09 10:38:40
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -325,7 +325,7 @@ CREATE TABLE `poi_logs` (
   `updated_at` datetime DEFAULT NULL,
   `action` varchar(255) DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -546,6 +546,7 @@ CREATE TABLE `users` (
   `reset_password_sent_at` datetime DEFAULT NULL,
   `toilet_counter` int(11) NOT NULL DEFAULT '0',
   `api_key` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `anonymous` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_authentication_token` (`authentication_token`),
   KEY `index_users_on_oauth_token` (`oauth_token`),
@@ -585,7 +586,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-07 13:45:26
+-- Dump completed on 2017-02-09  9:44:30
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -739,4 +740,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170202152914');
 INSERT INTO schema_migrations (version) VALUES ('20170206150119');
 
 INSERT INTO schema_migrations (version) VALUES ('20170207133358');
+
+INSERT INTO schema_migrations (version) VALUES ('20170209093420');
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -20,6 +20,16 @@ FactoryGirl.define do
     oauth_token 'token'
     oauth_secret 'secret'
   end
+
+  factory :wheelmap_visitor, class: User do
+    osm_username 'wheelmap_visitor'
+    first_name 'Wheelmap'
+    last_name 'Visitor'
+    email 'visitor@wheelmap.org'
+    terms true
+    privacy_policy true
+    oauth_token 'token'
+    oauth_secret 'secret'
+    anonymous true
+  end
 end
-
-

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -31,6 +31,10 @@ describe "Signup feature" do
     specify 'a new user exists' do
       expect(User.count).to eq 1
     end
+
+    specify "a user is not anonymous" do
+      expect(User.last.anonymous).to eq false
+    end
   end
 
   describe "I want to signup, too" do
@@ -42,6 +46,10 @@ describe "Signup feature" do
 
     specify "a user exists" do
       expect(User.count).to eq 1
+    end
+
+    specify "a user is not anonymous" do
+      expect(User.last.anonymous).to eq false
     end
   end
 


### PR DESCRIPTION
Related to #477 

This PR is a first step in the direction of ensuring that `wheelmap_android` and `wheelmap_visitor` are not able to create or update nodes via the wheelmap API.
Their only use case is to ensure that anonymous users are able to change the wheelchair and toilet status of an existing POI without the need of having an OpenStreetMap account.

We realize this change by introducing a new flag for users called `anonymous`. This is set to `false` for all users except `wheelmap_android` and `wheelmap_visitor`. Before a `create` or `update` action is performed we check if the current user has this flag set. If yes, the request is denied with a 403. This will result in failing requests for very old Android deployments (installations from the time span between early 2011 and late 2012) and breaks with expected behavior. This is breaking change is intended because the business requirement clearly says that `wheelmap_android` cannot create/update POIs.