### PR TITLE
Update osm oauth dev server url

### DIFF
--- a/config/open_street_map.SAMPLE.yml
+++ b/config/open_street_map.SAMPLE.yml
@@ -12,4 +12,4 @@ test:
   password: osm_password
   oauth_secret: ''
   oauth_key: ''
-  oauth_site: 'http://api06.dev.openstreetmap.org'
+  oauth_site: 'https://master.apis.dev.openstreetmap.org/'

--- a/config/open_street_map.SAMPLE.yml
+++ b/config/open_street_map.SAMPLE.yml
@@ -3,7 +3,7 @@ development:
   password: osm_password
   oauth_secret: '17UAT3a4n3xLCgvu7GZC37v9cY47jXszoNw9lL9w7I'
   oauth_key: '1uMcFjkJIlpFRHx7Y05Q'
-  oauth_site: 'http://api06.dev.openstreetmap.org'
+  oauth_site: 'https://master.apis.dev.openstreetmap.org/'
   # oauth_site: 'http://www.openstreetmap.org'
   xapi_site: 'http://www.informationfreeway.org'
 


### PR DESCRIPTION
As reported in #573 in the browser we receive a HTTP 500 when we try to log in with OpenStreetMap on Staging right now. In the server logs we can see that the OAuth API call results in a `Net::HTTPRetriableError (301 "Moved Permanently")`.

According to https://wiki.openstreetmap.org/wiki/OAuth the dev environment's url has been changed from https://api06.dev.openstreetmap.org/oauth to https://master.apis.dev.openstreetmap.org/. So we change this our side as well.