### PR TITLE
568-cleanup/unused translation keys

### DIFF
--- a/config/locales/de/active_admin.yml
+++ b/config/locales/de/active_admin.yml
@@ -104,6 +104,7 @@ de:
       admin_user:
         invalid: Benutzername oder Kennwort nicht korrekt.
         unauthenticated: Bitte melden Sie sich als Administrator an.
+        not_found_in_database: Benutzername existiert nicht, bitte versuchen Sie eine andere E-Mail-Adresse.
     sessions:
       admin_user:
         signed_in: Erfolgreich als Administrator angemeldet.

--- a/config/locales/de/dates.yml
+++ b/config/locales/de/dates.yml
@@ -64,16 +64,7 @@ de:
       about_x_years:
         one: "etwa 1 Jahr"
         other: "etwa %{count} Jahre"
-      almost_x_years:
-        one: "fast 1 Jahr"
-        other: "fast %{count} Jahre"
       half_a_minute: "eine halbe Minute"
-      less_than_x_minutes:
-        one: "weniger als eine Minute"
-        other: "weniger als %{count} Minuten"
-      less_than_x_seconds:
-        one: "weniger als eine Sekunde"
-        other: "weniger als %{count} Sekunden"
       over_x_years:
         one: "mehr als 1 Jahr"
         other: "mehr als %{count} Jahre"
@@ -89,10 +80,3 @@ de:
       x_seconds:
         one: "1 Sekunde"
         other: "%{count} Sekunden"
-    prompts:
-      day: Tag
-      hour: Stunde
-      minute: Minute
-      month: Monat
-      second: Sekunde
-      year: Jahr

--- a/config/locales/de/relaunch.yml
+++ b/config/locales/de/relaunch.yml
@@ -37,7 +37,6 @@ de:
       2: Ich habe mehr Informationen zum Ort.
   header:
     navigation:
-      about_wheelmap: Über Wheelmap
       choose_language: Sprache wählen
       contact: Kontakt
       map: Karte


### PR DESCRIPTION
This PR removes unused keys and adds a missing key to the german locale files.

Fixes #568.