### PR TITLE
Fix/remove session functionality for api clients

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -160,9 +160,8 @@ class Api::ApiController < ApplicationController
 
   def authenticate_by_token
     api_key = params[:api_key] || request.headers["X-API-KEY"]
-    if api_key && @current_user = User.find_by_authentication_token(api_key)
-      sign_in(:user, current_user)
-    end
+    @current_user = User.find_by_authentication_token(api_key)
+    return if api_key && @current_user
     render_exception_without_notification(Exception.new('invalid API key.'), 401) unless current_user
   end
 

--- a/spec/controllers/api/categories_controller_spec.rb
+++ b/spec/controllers/api/categories_controller_spec.rb
@@ -22,32 +22,6 @@ describe Api::CategoriesController do
       expect(@categories).not_to be_empty
     end
 
-    # TODO reenable terms feature
-    describe 'terms' do
-
-      describe 'accepted' do
-
-        it "should save tracking parameter" do
-          get(:index, :api_key => user.authentication_token)
-          user.reload
-          assert_equal 1, user.sign_in_count
-        end
-      end
-
-      describe 'not accepted' do
-
-        let :user do
-          FactoryGirl.create(:user, :terms => false)
-        end
-
-        it "should not save tracking parameter" do
-          get(:index, :api_key => user.authentication_token)
-          user.reload
-          assert_equal 0, user.sign_in_count
-        end
-      end
-    end
-
     describe 'format json' do
 
       it "should render json when using accept header" do

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'capybara/poltergeist'
+
+feature 'User login feature' do
+  describe 'Api clients do not get a session' do
+    given!(:user) { FactoryGirl.create(:user,
+      first_name: 'Wheelmap',
+      email: 'horst@wheelmap.org',
+      password: 'password',
+      password_confirmation: 'password',
+      confirmed_at: '10.10.1999',
+      osm_id: 174
+    )}
+
+    before do
+      visit "/api/nodes/?api_key=#{user.authentication_token}"
+      visit root_path
+    end
+
+    # We ensure that we are not logged in with following tests:
+    specify 'I see the login button.' do
+      expect(page).to have_content('Login')
+    end
+
+    specify 'I can not see the logout button.' do
+      expect(page).to_not have_content('Logout')
+    end
+  end
+end


### PR DESCRIPTION
When calling `api/nodes?api_key={api_key}` via the browser our app currently returns a login session that results in a `logged-in` state for that api client. 

This PR removes the possibility for api clients to get login sessions and fixes Github issue: https://github.com/sozialhelden/wheelmap-privateissues/issues/42