### PR TITLE
Collapse google streetview when not available

### DIFF
--- a/app/assets/javascripts/nodes.coffee
+++ b/app/assets/javascripts/nodes.coffee
@@ -267,8 +267,9 @@ if $dropzoneClickable.length > 0
 
   streetViewService.getPanorama streetViewLocationRequest, (data, status) ->
     unless status == google.maps.StreetViewStatus.OK
-      streetViewContainer = document.getElementById('streetview')
-      streetViewContainer.classList.add('invisible')
+      nodeStreetView = document.getElementsByClassName('node-streetview')
+      return if nodeStreetView.length == 0
+      nodeStreetView[0].classList.add('invisible')
       return
 
     heading = google.maps.geometry.spherical.computeHeading(data.location.latLng, position)

--- a/app/assets/javascripts/nodes.coffee
+++ b/app/assets/javascripts/nodes.coffee
@@ -267,6 +267,8 @@ if $dropzoneClickable.length > 0
 
   streetViewService.getPanorama streetViewLocationRequest, (data, status) ->
     unless status == google.maps.StreetViewStatus.OK
+      streetViewContainer = document.getElementById('streetview')
+      streetViewContainer.classList.add('invisible')
       return
 
     heading = google.maps.geometry.spherical.computeHeading(data.location.latLng, position)

--- a/app/assets/stylesheets/relaunch/_nodes.scss
+++ b/app/assets/stylesheets/relaunch/_nodes.scss
@@ -838,6 +838,10 @@ $node-photos-width: (100% - $node-photos-gutter * $node-photos-columns) / $node-
     width: 100%;
     @include box-sizing(border-box);
   }
+
+  .invisible {
+    display: none;
+  }
 }
 
 .osm-streetview {

--- a/app/assets/stylesheets/relaunch/_nodes.scss
+++ b/app/assets/stylesheets/relaunch/_nodes.scss
@@ -839,7 +839,7 @@ $node-photos-width: (100% - $node-photos-gutter * $node-photos-columns) / $node-
     @include box-sizing(border-box);
   }
 
-  .invisible {
+  &.invisible {
     display: none;
   }
 }

--- a/app/views/nodes/_node_on_osm.html.haml
+++ b/app/views/nodes/_node_on_osm.html.haml
@@ -1,0 +1,8 @@
+%section.node-osm
+  .pull-right
+    %p
+      %small
+        - if node_on_osm.osm_id < 0
+          = link_to t('nodes.show.show-in-osm'), "http://openstreetmap.org/browse/way/#{node_on_osm.osm_id.abs}"
+        - else
+          = link_to t('nodes.show.show-in-osm'), "http://openstreetmap.org/browse/node/#{node_on_osm.osm_id}"

--- a/app/views/nodes/_node_streetview.html.haml
+++ b/app/views/nodes/_node_streetview.html.haml
@@ -1,10 +1,3 @@
 %section.node-streetview
   %h2=t('.streetview')
   %p.node-streetview-viewport#streetview{ 'data-lat': node_streetview.lat, 'data-lon': node_streetview.lon }
-  .pull-right
-    %p
-      %small
-        - if node_streetview.osm_id < 0
-          = link_to t('nodes.show.show-in-osm'), "http://openstreetmap.org/browse/way/#{node_streetview.osm_id.abs}"
-        - else
-          = link_to t('nodes.show.show-in-osm'), "http://openstreetmap.org/browse/node/#{node_streetview.osm_id}"

--- a/app/views/nodes/show.html.haml
+++ b/app/views/nodes/show.html.haml
@@ -12,6 +12,7 @@
           = render partial: 'node_note', object: @node
           = render partial: 'node_streetview', object: @node
           = render partial: 'node_mapillary', object: @node
+          = render partial: 'node_on_osm', object: @node
 
         %section.node-aside.span4
           = render partial: 'node_edit', object: @node


### PR DESCRIPTION
PR for #571 

This collapses the Google Streetview widget when there's nothing to show. Also for aesthetics the "Show on OpenStreetMap" link is now below the Mapillary widget. 