### PR TITLE
Specify class name to fix 500 internal server error (caused by inherited resources)

### DIFF
--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -6,7 +6,7 @@ class Api::NodesController < Api::ApiController
   custom_actions collection: :search, member: :update_wheelchair
 
   optional_belongs_to :category, class_name: 'Category'
-  optional_belongs_to :node_type
+  optional_belongs_to :node_type, class_name: 'NodeType'
 
   # Make sure user authenticates itself using an api_key
   before_filter :authenticate_application!, only: [:update, :create]


### PR DESCRIPTION
When trying to call `/api/node_types/4/nodes?api_key=obfuscated` we get a `500 Internal server error`. In order to fix this we specify a class  name for this inherited resource scope, in this case: `NodeType`.

This PR fixes #589.

Result:
![00000276](https://cloud.githubusercontent.com/assets/4077916/24394325/d42d219a-139b-11e7-81f4-cac1b571b9ae.png)


