### PR TITLE
Update db/structure.sql to reflect #569

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,6 @@
 -- MySQL dump 10.13  Distrib 5.6.16, for debian-linux-gnu (x86_64)
 --
--- Host: localhost    Database: wheelmap_test
+-- Host: localhost    Database: wheelmap_development
 -- ------------------------------------------------------
 -- Server version	5.6.16-1~exp1
 
@@ -586,7 +586,7 @@ CREATE TABLE `widgets` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-09 10:38:40
+-- Dump completed on 2017-03-29 10:32:03
 INSERT INTO schema_migrations (version) VALUES ('20110107131649');
 
 INSERT INTO schema_migrations (version) VALUES ('20110114163727');
@@ -742,4 +742,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170206150119');
 INSERT INTO schema_migrations (version) VALUES ('20170207133358');
 
 INSERT INTO schema_migrations (version) VALUES ('20170209093420');
+
+INSERT INTO schema_migrations (version) VALUES ('20170217131434');
 


### PR DESCRIPTION
In https://github.com/sozialhelden/wheelmap/pull/569 we added a migration and the `db/structure.sql` was updated.

However looking at https://github.com/sozialhelden/wheelmap/pull/569/files#diff-f9ae8314082d8229b38da27dd6c2642dR744 and the added migrations (https://github.com/sozialhelden/wheelmap/pull/569/files#diff-9de2aac40ba6049cfa3156c18d011823R1 and https://github.com/sozialhelden/wheelmap/pull/569/files#diff-5e7f87355f820cac0c5077264bebcaa9R1) it seems like only one migration was run on the structure.

This PR runs the other migration on and updates the `db/structure.sql`.

Please take note of https://github.com/sozialhelden/wheelmap/pull/569/files#r108650327, in particular:

> Any newly created production environment using these two users will need to manually go and set these users to anonymous after creating them (also a manual process).

This fixes a problem with the vagrant provisioning not creating any nodes.