### PR TITLE
Add rgeo packages to locate pois

### DIFF
--- a/vagrant/privileged_setup.sh
+++ b/vagrant/privileged_setup.sh
@@ -34,7 +34,11 @@ apt-get install -y \
   ruby-dev \
   nodejs-legacy \
   npm \
-  phantomjs
+  phantomjs \
+  libffi-dev \
+  libgeos-dev \
+  libproj-dev \
+  libgdal-dev
 
 gem install bundler
 


### PR DESCRIPTION
This PR brings back the rgeo ubuntu packages that are needed for the gem `rgeo`.

In case you are running into issues: After updating your provisioning, please make sure to remove `.bundle` to have a clean state before running `gem install bundler` and `bundle install`.

Related Github issue: #601 