### PR TITLE
Fix encoding error on csv upload

### DIFF
--- a/app/models/provided_poi.rb
+++ b/app/models/provided_poi.rb
@@ -10,7 +10,7 @@ class ProvidedPoi < ActiveRecord::Base
   def self.import(provider_id, csv_file)
     provider = Provider.find(provider_id)
     success_count = 0
-    CSV.parse(csv_file.force_encoding('UTF-8'), headers: true, header_converters: :symbol, col_sep: ';', row_sep: :auto) do |row|
+    CSV.parse(csv_file.force_encoding('UTF-8'), headers: true, header_converters: :symbol, col_sep: ';') do |row|
       osm_id = row[:osm_id].to_i
       osm_id = row[:osm_type] == 'way' ? osm_id * -1 : osm_id
       provided_poi = provider.provided_pois.where(poi_id: osm_id).first_or_initialize

--- a/app/models/provided_poi.rb
+++ b/app/models/provided_poi.rb
@@ -10,7 +10,7 @@ class ProvidedPoi < ActiveRecord::Base
   def self.import(provider_id, csv_file)
     provider = Provider.find(provider_id)
     success_count = 0
-    CSV.parse(csv_file, headers: true, encoding: 'UTF-8', header_converters: :symbol) do |row|
+    CSV.parse(csv_file.force_encoding('UTF-8'), headers: true, header_converters: :symbol, col_sep: ';', row_sep: :auto) do |row|
       osm_id = row[:osm_id].to_i
       osm_id = row[:osm_type] == 'way' ? osm_id * -1 : osm_id
       provided_poi = provider.provided_pois.where(poi_id: osm_id).first_or_initialize


### PR DESCRIPTION
This PR fixes 2 bugs:

a) when trying to upload a csv in the admin dashboard we get:
```
Encoding::UndefinedConversionError ("\xC3" from ASCII-8BIT to UTF-8)
```

b) when trying to upload 19 records from an example csv, the system only recognizes 1 record when no column separators are set in the headers options of the csv.

Related Github issue: https://github.com/sozialhelden/wheelmap/issues/611