### PR TITLE
[WIP] Introduce new premium provider Heidelberg Huerdenlos

### DIFF
--- a/lib/tasks/huerdenlos.rake
+++ b/lib/tasks/huerdenlos.rake
@@ -1,0 +1,57 @@
+# encoding: UTF-8
+
+namespace :import do
+  desc 'Import data from Heidelberg Hürdenlos'
+  task from_heidelberg_huerdenlos: :environment do
+
+    # This method needs to be on top otherwise it would take the method `wheelchair_status_from` from `import.rake` file
+    def wheelchair_status_from(aa_ampel)
+      case aa_ampel
+      when 'Grün' then 'yes'
+      when 'Gelb' then 'limited'
+      when 'Rot' then 'no'
+      else
+        'unknown'
+      end
+    end
+
+    poi = nil
+    skipped = Hash.new(0)
+    saved = Hash.new(0)
+
+    file_name = ENV['FILE']
+    raise 'Use bundle exec rake import:from_heidelberg_huerdenlos FILE=<file_name>' unless file_name
+    provider = Provider.find_or_create_by(name: 'Heidelberg Hürdenlos')
+
+    CSV.foreach(file_name, force_quotes: true, headers: true, encoding: 'UTF-8', header_converters: :symbol, col_sep: ';', row_sep: :auto) do |row|
+      osm_id = row[:osm_id]
+
+      if osm_id.blank?
+        # Each csv record must refer to a unique identifier (osm_id), otherwise skip
+        puts "Skipped: osm_id blank!"
+        skipped[:removed] += 1
+        next
+      else
+        # Find the POI in the DB
+        poi = Poi.find_or_initialize_by(osm_id: osm_id)
+
+        if poi
+          provided_poi = ProvidedPoi.find_or_initialize_by(poi_id: osm_id, provider_id: provider.id)
+          provided_poi.wheelchair = wheelchair_status_from(row[:aa_ampel])
+          provided_poi.url        = row[:aa_direktlink]
+          provided_poi.save!
+          saved[:success] += 1
+          puts "Saved ProvidedPoi with osm_id #{provided_poi.poi_id}."
+        else
+          puts "Skipped: osm_id #{osm_id} found in CSV but POI not found in the DB."
+          skipped[:not_found] += 1
+          next
+        end
+      end
+    end
+    puts
+    puts "Skipped: #{skipped[:removed]} POI (removed)"
+    puts "Skipped: #{skipped[:not_found]} POI (not found)"
+    puts "Saved: #{saved[:success]} ProvidedPoi"
+  end
+end


### PR DESCRIPTION
This PR imports data from the new provider `Heidelberg Hürdenlos` for following attributes via a rake new task (`huerdenlos.rake`):

- `osm_id`=> `poi_id` (if there are any per record)
- `provided_poi.wheelchair` status
- `provided_poi.url`

**Important:**
At the moment we do not fetch data for `provided_poi.wheelchair_toilet`, this needs further clarifications since Hürdenlos uses `yes`, `limited`, `no` and `unknown` for the toilet status while wheelmap uses `yes`, `no` and `unknown` only.

**Example (dev env):**
```shell
+------+------------+-------------+------------+--------------------------------------------------------------------------------------------------------------------------------------+---------------------+---------------------+-------------------+
| id   | poi_id     | provider_id | wheelchair | url                                                                                                                                  | created_at          | updated_at          | wheelchair_toilet |
+------+------------+-------------+------------+--------------------------------------------------------------------------------------------------------------------------------------+---------------------+---------------------+-------------------+
| 4366 | 4127557146 |           3 | yes        | http://www.heidelberg.huerdenlos.de/index.php?id=980&huerdenlos[module_ratings][action]=detail&huerdenlos[module_ratings][dbid]=3538 | 2017-05-17 15:28:39 | 2017-05-17 15:28:39 | NULL              |
| 4367 | 4176950906 |           3 | limited    | http://www.heidelberg.huerdenlos.de/index.php?id=980&huerdenlos[module_ratings][action]=detail&huerdenlos[module_ratings][dbid]=4441 | 2017-05-17 15:28:39 | 2017-05-17 15:28:39 | NULL
```

Related Github issue: https://github.com/sozialhelden/wheelmap-privateissues/issues/44