### PR TITLE
Open the "Icons" link of the widget in new window.

### DIFF
--- a/app/assets/javascripts/views/map.view.js.coffee
+++ b/app/assets/javascripts/views/map.view.js.coffee
@@ -29,7 +29,7 @@ Wheelmap.TileLayer = EmberLeaflet.TileLayer.extend
   options:
     maxZoom: 19
     minZoom: 2
-    attribution: 'Data: <a href="http://www.openstreetmap.org/copyright">&copy; OpenStreetMap contributors</a>, Icons: CC-By-SA <a href="https://mapicons.mapsmarker.com/about/license/">Maps Icons Collection</a>'
+    attribution: 'Data: <a href="http://www.openstreetmap.org/copyright">&copy; OpenStreetMap contributors</a>, Icons: CC-By-SA <a href="https://mapicons.mapsmarker.com/about/license/" target="_blank">Maps Icons Collection</a>'
 
 Wheelmap.MarkerLayer = EmberLeaflet.Layer.extend
   mapBinding: 'parentLayer'


### PR DESCRIPTION
Currently it opens in the widget iframe. Fixes #610 