### PR TITLE
feat: keep vm clock update via ntp

### DIFF
--- a/vagrant/privileged_setup.sh
+++ b/vagrant/privileged_setup.sh
@@ -18,6 +18,7 @@ export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set pass
 
 # Install all dependencies
 apt-get install -y \
+  ntp \
   git \
   imagemagick \
   mysql-server-5.6 \


### PR DESCRIPTION
installs ntp preventing problems with ssh certificates not being active since a present date, when
vm has its clock set in the past