### PR TITLE
Add node_type to short node GeoJSON

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -323,6 +323,7 @@ class Poi < ActiveRecord::Base
                     'wheelchair_toilet' => wheelchair_toilet,
                     'id'         => osm_id,
                     'category'   => category.try(:identifier) || '',
+                    'node_type'  => node_type.try(:identifier) || '',
                     'icon'       => icon,
                     'name'       => name,
                     'sponsor'    => sponsored? ? sponsor : nil }


### PR DESCRIPTION
This allows the new frontend to use the node_type attribute for map markers.

Background: The new frontend includes a mechanism to categorize PoIs using synonymes. When developing accessibility.cloud, Holger, Thomas, Katharina and I unified the various systems we found. The new frontend displays subtly different icons for that reason, and to do this correctly, it needs the exact node_type info for each PoI.

Tested locally. Could somebody merge / deploy this? This is hopefully the last step for displaying markers from different sources on a map correctly in the new frontend 🤞🏻