### PR TITLE
Fix/argument error on datetime

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -7,7 +7,7 @@ class Photo < ActiveRecord::Base
   belongs_to :poi
   belongs_to :user, counter_cache: true
   mount_uploader :image, PhotoUploader
-  # This process is being used for Carierwave backgrounder delayed jobs for staging and production. 
+  # This process is being used for Carierwave backgrounder delayed jobs for staging and production.
   # Comment out this line to see the uploaded images immediately in dev mode.
   process_in_background :image
 
@@ -51,8 +51,18 @@ class Photo < ActiveRecord::Base
 
   def extract_date_time
     self.taken_at = begin
-                      EXIFR::JPEG.new(image.path).date_time
-                    rescue
+                      exif_date_time = EXIFR::JPEG.new(image.path).date_time
+                      date_time_str = /^\d{4}(:|-|\/)\d{2}(:|-|\/)\d{2}\s\d+(:)\d{2}(:)\d{2}\s\+\d{4,}\$/
+
+                      # Allowed date formats: '2017:04:22 03:00:22 +0200', '2017-06-08 13:40:32 +0200', '2017/06/08 1:40:32 +0200'
+                      if date_time_str.match(exif_date_time)
+                         exif_date_time
+                      else
+                        puts "EXIF date_time format '#{exif_date_time}' does not match with date_time."
+                        exif_date_time = nil
+                      end
+                    rescue StandardError
+                      puts "EXIF data is invalid."
                       nil
                     end
   end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -52,17 +52,17 @@ class Photo < ActiveRecord::Base
   def extract_date_time
     self.taken_at = begin
                       exif_date_time = EXIFR::JPEG.new(image.path).date_time
-                      date_time_str = /^\d{4}(:|-|\/)\d{2}(:|-|\/)\d{2}\s\d+(:)\d{2}(:)\d{2}\s\+\d{4,}\$/
+                      date_time_regex = /^\d{4}(:|-|\/)\d{2}(:|-|\/)\d{2}\s\d+(:)\d{2}(:)\d{2}\s\+\d{4,}\$/
 
                       # Allowed date formats: '2017:04:22 03:00:22 +0200', '2017-06-08 13:40:32 +0200', '2017/06/08 1:40:32 +0200'
-                      if date_time_str.match(exif_date_time)
+                      if date_time_regex.match(exif_date_time.to_s)
                          exif_date_time
                       else
-                        puts "EXIF date_time format '#{exif_date_time}' does not match with date_time."
+                        puts "EXIF date_time format '#{exif_date_time}' is not supported."
                         exif_date_time = nil
                       end
-                    rescue StandardError
-                      puts "EXIF data is invalid."
+                    rescue StandardError => e
+                      puts "EXIF date_time error message: #{e}"
                       nil
                     end
   end

--- a/lib/tasks/streetspotr.rake
+++ b/lib/tasks/streetspotr.rake
@@ -29,6 +29,7 @@ namespace :streetspotr do
 
     CSV.foreach(csv_file, converters: UTF8_TO_UTF8MB4_CONVERTER, headers: true, header_converters: :symbol, col_sep: ';', row_sep: :auto) do |row|
       osm_id = row[:osm_id]
+
       # Loop through CSV and check if record has osm_id
       if osm_id.blank?
         unless poi
@@ -40,6 +41,8 @@ namespace :streetspotr do
         begin
           # Find the POI
           poi = Poi.find_by!(osm_id: osm_id)
+           # Print osm_id for errors handling
+          puts "osm_id: #{osm_id}"
         rescue ActiveRecord::RecordNotFound
           puts "Skipped: POI for osm_id #{osm_id} not found."
           @not_found[:poi] += 1


### PR DESCRIPTION
At the moment we only fetch the EXIF date_time of an image (before photo creation) but we do not validate the format of the date_time. This PR specifies 3 ways of date_time, anything beyond them will set the EXIF date_time to `nil`.

- '2017:04:22 03:00:22 +0200'
- '2017-06-08 13:40:32 +0200'
- '2017/06/08 1:40:32 +0200'


Fixes Github issue: #633.
Github issue #630 is dependent on this PR.