### PR TITLE
Change date_time validation from regex to DateTime parser

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -51,19 +51,11 @@ class Photo < ActiveRecord::Base
 
   def extract_date_time
     self.taken_at = begin
-                      exif_date_time = EXIFR::JPEG.new(image.path).date_time
-                      date_time_regex = /^\d{4}(:|-|\/)\d{2}(:|-|\/)\d{2}\s\d+(:)\d{2}(:)\d{2}\s\+\d{4,}\$/
-
-                      # Allowed date formats: '2017:04:22 03:00:22 +0200', '2017-06-08 13:40:32 +0200', '2017/06/08 1:40:32 +0200'
-                      if date_time_regex.match(exif_date_time.to_s)
-                         exif_date_time
-                      else
-                        puts "EXIF date_time format '#{exif_date_time}' is not supported."
-                        exif_date_time = nil
-                      end
+                      exif_date_time = EXIFR::JPEG.new(image.path).date_time.to_s
+                      DateTime.parse(exif_date_time)
                     rescue StandardError => e
-                      puts "EXIF date_time error message: #{e}"
-                      nil
+                      puts "EXIF date_time format '#{exif_date_time}' is not supported: #{e}"
+                      exif_date_time = nil
                     end
   end
 


### PR DESCRIPTION
When executing the PR #634 on production we noticed that this string `2017-02-04 21:05:15 +0000` was not recognized as a valid string. 

**Error Example**
```
osm_id: 21302157
EXIF date_time format '2017-02-04 21:05:15 +0000' is not supported: no implicit conversion of Time into String
```
Even though this was fixed by using `to_s` on date_time, we decided to refactor the current validation to be on the safe side for the future.  Luckily the `DateTime` parser would parse most of the date_time formats we need for now.

Allowed date_time formats:
- "2017/07/10 5:21:29 AM"
- "2017/07/10 5:21:29 pm"
- "2017/07/10 5:21:29 p.m."
- "2017-07-10 5:21:29 a.m."
- "2017-07-10 5:21:29 +2000"

This is a follow-up PR of PR #634 and part of Github issue #633. 