### PR TITLE
Fix/wheelmap description missing on nodes

### DIFF
--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -27,6 +27,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
     logger.info "User DB ID: #{user.try(:id)} - User OSM ID: #{user.try(:osm_id)} - Element: #{element_id} - Tags: #{tags}"
 
     begin
+      # binding.pry
       element_to_compare = api.find_element(type, element_id)
 
       element = element_to_compare.dup
@@ -38,6 +39,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       end
 
       # This loop is only here to make tests fail, actually.
+      # binding.pry
       element.tags.each do |_key, _value|
         tags_to_delete.each do |delete_key, delete_value|
           raise 'Tags to be deleted are still to be found.' if element.tags.include?(delete_key) && element.tags[delete_key] == delete_value
@@ -47,7 +49,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       # Use spaceship operator for comparision:
       # as "element == element_to_compare" is false because of object_id
       comparison_value = (element_to_compare <=> element)
-
+      # binding.pry
       # Ignore this job, as there are no changes to be saved
       if comparison_value.zero?
         logger.info "IGNORE: #{type}:#{element_id} nothing has changed! (value comparison)"
@@ -57,6 +59,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       changeset = api.find_or_create_open_changeset(user.changeset_id, 'Modified via wheelmap.org')
       user.update_attribute(:changeset_id, changeset.id)
 
+      # binding.pry
       api.save(element, changeset)
       Counter.increment(source)
       increment_user_counter!

--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -128,6 +128,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
     p = Poi.find osm_id
     p.wheelchair = tags[WHEELCHAIR_TAG_KEY] if tags.key?(WHEELCHAIR_TAG_KEY)
     p.wheelchair_toilet = tags[WHEELCHAIR_TOILET_TAG_KEY] if tags.key?(WHEELCHAIR_TOILET_TAG_KEY)
+    p.wheelchair_description = tags['wheelchair:description'] if tags.key?('wheelchair:description')
     p.save(validate: false)
   rescue Exception => e
     logger.error e.message

--- a/app/jobs/update_tags_job.rb
+++ b/app/jobs/update_tags_job.rb
@@ -27,9 +27,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
     logger.info "User DB ID: #{user.try(:id)} - User OSM ID: #{user.try(:osm_id)} - Element: #{element_id} - Tags: #{tags}"
 
     begin
-      # binding.pry
       element_to_compare = api.find_element(type, element_id)
-
       element = element_to_compare.dup
       element.tags.merge!(tags)
       tags_to_delete.each do |delete_key, delete_value|
@@ -39,7 +37,6 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       end
 
       # This loop is only here to make tests fail, actually.
-      # binding.pry
       element.tags.each do |_key, _value|
         tags_to_delete.each do |delete_key, delete_value|
           raise 'Tags to be deleted are still to be found.' if element.tags.include?(delete_key) && element.tags[delete_key] == delete_value
@@ -49,7 +46,7 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       # Use spaceship operator for comparision:
       # as "element == element_to_compare" is false because of object_id
       comparison_value = (element_to_compare <=> element)
-      # binding.pry
+
       # Ignore this job, as there are no changes to be saved
       if comparison_value.zero?
         logger.info "IGNORE: #{type}:#{element_id} nothing has changed! (value comparison)"
@@ -59,7 +56,6 @@ class UpdateTagsJob < Struct.new(:element_id, :type, :tags, :user, :client, :sou
       changeset = api.find_or_create_open_changeset(user.changeset_id, 'Modified via wheelmap.org')
       user.update_attribute(:changeset_id, changeset.id)
 
-      # binding.pry
       api.save(element, changeset)
       Counter.increment(source)
       increment_user_counter!

--- a/spec/jobs/update_tags_job_spec.rb
+++ b/spec/jobs/update_tags_job_spec.rb
@@ -133,11 +133,11 @@ describe UpdateTagsJob do
     expect(failures).to eql 0
   end
 
-  it 'updates and returns wheelchair description tags' do
+  it 'compares and updates wheelchair description tag' do
     example_poi = FactoryGirl.build(:poi)
     example_poi.tags = { 'name' => 'name' }
     example_poi.save!
-    tags = { 'wheelchair:description' => 'Stufe am Eingang, aber rollstuhlgerechtes WC' }
+    tags = { 'wheelchair:description' => 'Keine Rampe hohe Treppen' }
 
     example_node = Rosemary::Node.new(tag: { 'wheelchair:description'=> 'Stufe am Eingang, aber rollstuhlgerechtes WC' })
     UpdateTagsJob.enqueue(example_poi.id.abs, example_poi.osm_type, tags, user, 'update_iphone')
@@ -145,12 +145,12 @@ describe UpdateTagsJob do
     expect(Rosemary::Api).to receive(:new).and_return(api)
     expect(api).to receive(:find_element).and_return(example_node)
     expect(api).to receive(:save) do |node, _|
-      expect(node.tags['wheelchair:description']).to eql 'Stufe am Eingang, aber rollstuhlgerechtes WC'
+      expect(node.tags['wheelchair:description']).to eql 'Keine Rampe hohe Treppen'
     end
 
     successes, failures = Delayed::Worker.new.work_off
     example_poi.reload
-    expect(example_poi.wheelchair_description).to eq('Stufe am Eingang, aber rollstuhlgerechtes WC')
+    expect(example_poi.wheelchair_description).to eq('Keine Rampe hohe Treppen')
     expect(successes).to eql  1
     expect(failures).to eql 0
   end

--- a/spec/jobs/update_tags_job_spec.rb
+++ b/spec/jobs/update_tags_job_spec.rb
@@ -42,7 +42,7 @@ describe UpdateTagsJob do
     expect(api).to receive(:find_element).with('node', node.id.abs).and_return(unedited_node)
     expect(api).not_to receive(:save)
     successes, failures = Delayed::Worker.new.work_off
-    expect(successes).to eql  1
+    expect(successes).to eql 1
     expect(failures).to eql 0
   end
 
@@ -133,7 +133,7 @@ describe UpdateTagsJob do
     expect(failures).to eql 0
   end
 
-  it 'compares and updates wheelchair description tag' do
+  it 'updates wheelchair description tag' do
     example_poi = FactoryGirl.build(:poi)
     example_poi.tags = { 'name' => 'name' }
     example_poi.save!
@@ -151,7 +151,7 @@ describe UpdateTagsJob do
     successes, failures = Delayed::Worker.new.work_off
     example_poi.reload
     expect(example_poi.wheelchair_description).to eq('Keine Rampe hohe Treppen')
-    expect(successes).to eql  1
+    expect(successes).to eql 1
     expect(failures).to eql 0
   end
 

--- a/spec/jobs/update_tags_job_spec.rb
+++ b/spec/jobs/update_tags_job_spec.rb
@@ -151,7 +151,11 @@ describe UpdateTagsJob do
   end
 
   it 'returns wheelchair tags data from osm' do
-    UpdateTagsJob.enqueue(poi.id.abs, poi.osm_type, poi.tags, user, 'update_iphone', {'wheelchair:description' => true })
+    example_poi = FactoryGirl.build(:poi)
+    example_poi.tags = { 'name' => 'name' }
+    example_poi.save!
+
+    UpdateTagsJob.enqueue(example_poi.id.abs, example_poi.osm_type, example_poi.tags, user, 'update_iphone', {'wheelchair:description' => true })
     api = double(find_or_create_open_changeset: changeset)
     expect(Rosemary::Api).to receive(:new).and_return(api)
     expect(api).to receive(:find_element).and_return(updated_node)


### PR DESCRIPTION
This PR fixes **behavior one** listed in issue (https://github.com/sozialhelden/wheelmap/issues/606#issuecomment-315998907) :
- Some text being posted in the comment/description section of affected POIs are not saved to the wheelmap database and therefore do not show up on a wheelmap POI detail page even though they are visible on osm. 

Fix:
- in the `update_poi!` method we previously only saved the tags `wheelchair` and `toilets:wheelchair` but not `wheelchair:description` until now.

