### PR TITLE
Fix issues with /beta/* route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ public/assets
 public/sitemap*
 public/system/sitemap*
 public/system/uploads*
+public/beta
 vendor/bundle
 vendor/cache
 node_modules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,5 +171,6 @@ Wheelmap::Application.routes.draw do
 
   get '/dashboard', to: redirect('https://metrics.librato.com/share/dashboards/3wf885ot?duration=604800')
   get '/',          to: redirect('/map'), as: 'roooot'
-  match '/beta', to: 'react#index', via: [:get]
+  match '/beta/*a', to: 'react#index', via: [:get]
+  match '/beta',    to: 'react#index', via: [:get]
 end


### PR DESCRIPTION
This PR allows child routes of `/beta` to reach the react controller. We also put `public/beta` to `.gitignore` for local development.

Related Github issue: #644 