### PR TITLE
Close up: Ignore development env for airbrake

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -5,7 +5,7 @@ Airbrake.configure do |config|
   config.project_id = ENV['AIRBRAKE_PROJECT_ID']
   config.project_key = ENV['AIRBRAKE_API_KEY']
   config.environment = Rails.env
-  config.ignore_environments = %w(test)
+  config.ignore_environments = %w(test development)
   config.root_directory = Rails.root
   config.blacklist_keys = [/password/i, /authorization/i]
   config.logger = Rails.logger


### PR DESCRIPTION
This PR is a follow-up of #654 and ignores `dev` env for airbrake errors. 

Related Github issue: https://github.com/sozialhelden/wheelmap-privateissues/issues/50