### PR TITLE
Fix check if exception class should be ignored in airbrake

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -20,7 +20,7 @@ Airbrake.configure do |config|
       'Net::ReadTimeout'
     ]
 
-    if ignored_exceptions.include?(notice.stash[:exception].to_s)
+    if ignored_exceptions.include?(notice.stash[:exception].class.to_s)
       notice.ignore!
     else
       Aibrake.notify(notice)


### PR DESCRIPTION
We noticed that on airbrake the error `Rosemary::Unavailable: Service Unavailable` hasn't been ignored. This PR checks if the exception class is also ignored in airbrake. 

Follow-up PR for  PR #654 & #655. 