### PR TITLE
search fix: use https for nominatim

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,5 @@
 class SearchController < ApplicationController
-  URL = 'http://nominatim.openstreetmap.org/search'.freeze
+  URL = 'https://nominatim.openstreetmap.org/search'.freeze
   # URL = "http://open.mapquestapi.com/nominatim/v1/search"
   DEFAULT_PARAMS = { limit: 10, email: 'info@wheelmap.org', dedupe: '1' }.freeze
   USERAGENT = 'Wheelmap v1.0, (http://wheelmap.org)'.freeze

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,6 +15,8 @@ class SearchController < ApplicationController
   def index
     @search_url = URI.parse(URL)
     @http = Net::HTTP.new(@search_url.host, @search_url.port)
+    @http.use_ssl = true
+    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     @http.read_timeout = 2
     @http.open_timeout = 2
     @query = DEFAULT_PARAMS.reverse_merge('accept-language': I18n.locale, q: params[:q])

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
     @search_url = URI.parse(URL)
     @http = Net::HTTP.new(@search_url.host, @search_url.port)
     @http.use_ssl = true
-    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     @http.read_timeout = 2
     @http.open_timeout = 2
     @query = DEFAULT_PARAMS.reverse_merge('accept-language': I18n.locale, q: params[:q])

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rexml/document'
 
 describe SearchController do
   before :each do
-    @search_api_url = 'http://nominatim.openstreetmap.org/search?q=Leipziger+Strasse%2C+Berlin&format=xml&limit=10&accept-language=de&dedupe=1&email=info%40wheelmap.org'
+    @search_api_url = 'https://nominatim.openstreetmap.org/search?q=Leipziger+Strasse%2C+Berlin&format=xml&limit=10&accept-language=de&dedupe=1&email=info%40wheelmap.org'
 
     stub_request(:get, @search_api_url)
       .to_return(status: 200, body: File.read("#{Rails.root}/spec/fixtures/search.xml"))


### PR DESCRIPTION
This PR ensures that `https` is being used for the search function that is based on nominatim.openstreetmap.org.

Fixes Github issue: https://github.com/sozialhelden/wheelmap/issues/674
