### PR TITLE
Fix: Upgrade and pin jquery-ui-rails ~> 5.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :default do
   gem 'compass'
   gem 'compass-colors'
   gem 'compass-rails', '~> 3.0.2'
-  gem 'jquery-rails', '2.3.0'
+  gem 'jquery-ui-rails', '~> 5.0.5'
   gem 'sass', '~>3.3' # >= 3.3 is needed for BEM syntax
   gem 'sass-rails'
   gem 'sprockets-es6', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
     jquery-rails (2.3.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
+    jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     js-routes (1.4.4)
       railties (>= 3.2)
@@ -638,7 +638,7 @@ DEPENDENCIES
   i18n (< 0.7.0)
   i18n-js (~> 3.0.0.rc9)
   inherited_resources (~> 1.6.0)
-  jquery-rails (= 2.3.0)
+  jquery-ui-rails (~> 5.0.5)
   js-routes
   json-schema (~> 2.7)
   kaminari (~> 0.14)


### PR DESCRIPTION
During deployment of `Removing airbrake` (https://github.com/sozialhelden/wheelmap/pull/682) to **staging** we encountered following assets precompile error:

```
rake aborted!
Sprockets::FileNotFound: couldn't find file 'jquery-ui/datepicker' with type 'application/javascript'
```

Link to solution: https://github.com/activeadmin/activeadmin/issues/4672

This PR upgrades and pins `jquery-ui-rails ~> 5.0.5` to ensure assets precompiling works again. 