### PR TITLE
[Fix] Pin Capistrano '~>3.4' & Capistrano-Deploytags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,10 +124,10 @@ group :production, :vagrant do
 end
 
 group :development do
-  gem 'capistrano', '>= 3.1.0'
-  gem 'capistrano-bundler',                 require: false
-  gem 'capistrano-deploytags', '~> 1.0.0',  require: false
-  gem 'capistrano-npm',                     require: false
-  gem 'capistrano-rails',                   require: false
-  gem 'capistrano-rbenv',                   require: false
+  gem 'capistrano', '~>3.4'
+  gem 'capistrano-deploytags', '~> 1.0', '>= 1.0.6',   require: false # depends on Capistrano '>= 3.2.0' and '<= 3.4.x'
+  gem 'capistrano-bundler',                            require: false
+  gem 'capistrano-npm',                                require: false
+  gem 'capistrano-rails',                              require: false
+  gem 'capistrano-rbenv',                              require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
     aggregate (0.2.2)
-    airbrussh (1.3.0)
-      sshkit (>= 1.6.1, != 1.7.0)
     apipie-rails (0.5.8)
       rails (>= 4.1)
     arbre (1.1.1)
@@ -118,16 +116,15 @@ GEM
     cacheable_flash (1.0.0)
       json
       stackable_flash (>= 0.0.7)
-    capistrano (3.10.2)
-      airbrussh (>= 1.0.0)
+    capistrano (3.4.1)
       i18n
       rake (>= 10.0.0)
-      sshkit (>= 1.9.0)
+      sshkit (~> 1.3)
     capistrano-bundler (1.3.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-deploytags (1.0.7)
-      capistrano (>= 3.7.0)
+    capistrano-deploytags (1.0.6)
+      capistrano (>= 3.2.0)
     capistrano-npm (1.0.2)
       capistrano (>= 3.0.0)
     capistrano-rails (1.3.1)
@@ -595,9 +592,9 @@ DEPENDENCIES
   bootstrap-sass (~> 2.3)
   browserify-rails (~> 3.1.0)
   cacheable_flash
-  capistrano (>= 3.1.0)
+  capistrano (~> 3.4)
   capistrano-bundler
-  capistrano-deploytags (~> 1.0.0)
+  capistrano-deploytags (~> 1.0, >= 1.0.6)
   capistrano-npm
   capistrano-rails
   capistrano-rbenv
@@ -694,4 +691,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
When we deployed PR #682 & #683 to staging everything worked as expected but when we deployed  these PRs to `production` with capistrano it suddenly required a ssh passphrase. Even when we typed in the correct password it did not accept it which let the deployment being stuck at that point. 

In debugging mode we got following error:

```
Net::SSH::AuthenticationFailed: Authentication failed for user vagrant@xx.x.xx.x...
```

**Background info:**
Since Capistrano version '> 3.2.0' a ssh password feature is provided for deployment. As long as we don't adjust the deployment settings we would need to downgrade back to the previous capistrano version that is BEFORE '~>3.7' (otherwise it would not work together with capistrano-deploymentags).

More info: http://capistranorb.com/documentation/faq/how-can-i-get-capistrano-to-prompt-for-a-password/

This PR does following:
- downgrades to Capistrano '~>3.4.x'
- downgrades to Capistrano-Deploytags to '~> 1.0', '>= 1.0.6'
- upgrades to Bundler v1.16.2